### PR TITLE
SPMM-2745 this could be the change that Chris was describing in order to switch to the new j9 content sets and drop the need for package-level deps

### DIFF
--- a/codeready-workspaces-plugin-java11-openj9/container.yaml
+++ b/codeready-workspaces-plugin-java11-openj9/container.yaml
@@ -9,11 +9,6 @@ platforms:
 
 compose:
   inherit: true
-  packages:
-  - java-11-openj9
-  - java-11-openj9-headless
-  - java-11-openj9-devel
-  - java-11-openj9-src
   pulp_repos: true
   signing_intent: release
 

--- a/codeready-workspaces-plugin-java11-openj9/content_sets.yml
+++ b/codeready-workspaces-plugin-java11-openj9/content_sets.yml
@@ -16,7 +16,9 @@ s390x:
 - rhel-8-for-s390x-baseos-rpms
 - rhel-8-for-s390x-appstream-rpms
 - rhocp-4.4-for-rhel-8-s390x-rpms
+- openj9-1-for-rhel-8-s390x-rpms
 ppc64le:
 - rhel-8-for-ppc64le-baseos-rpms
 - rhel-8-for-ppc64le-appstream-rpms
 - rhocp-4.4-for-rhel-8-ppc64le-rpms
+- openj9-1-for-rhel-8-ppc64le-rpms 

--- a/codeready-workspaces-plugin-java11-openj9/get-sources-jenkins.sh
+++ b/codeready-workspaces-plugin-java11-openj9/get-sources-jenkins.sh
@@ -7,6 +7,7 @@ JOB_BRANCH=""
 doRhpkgContainerBuild=1
 forceBuild=0
 forcePull=0
+targetFlag=""
 
 while [[ "$#" -gt 0 ]]; do
   case $1 in
@@ -37,9 +38,9 @@ if [ -z "$JOB_BRANCH" ] ; then
 		log "[ERROR] JOB_BRANCH was not specified"
 		exit 1
 fi
-if [[ ! ${targetFlag} ]]; then
-	targetFlag="--target crw-${JOB_BRANCH}-openj9-rhel-8-containers-candidate" # required for resolving openj9 artifacts 
-fi
+# if [[ ! ${targetFlag} ]]; then
+# 	targetFlag="--target crw-${JOB_BRANCH}-openj9-rhel-8-containers-candidate" # required for resolving openj9 artifacts 
+# fi
 
 # CRW-611 GraalVM CE and native-image version from https://github.com/graalvm/graalvm-ce-builds/releases/ (includes JDK 11)
 # GRAALVM_VERSION="19.3.1"

--- a/codeready-workspaces-plugin-java8-openj9/container.yaml
+++ b/codeready-workspaces-plugin-java8-openj9/container.yaml
@@ -9,10 +9,6 @@ platforms:
 
 compose:
   inherit: true
-  packages:
-  - java-1.8.0-openj9
-  - java-1.8.0-openj9-devel
-  - java-1.8.0-openj9-headless
   pulp_repos: true
   signing_intent: release
 

--- a/codeready-workspaces-plugin-java8-openj9/content_sets.yml
+++ b/codeready-workspaces-plugin-java8-openj9/content_sets.yml
@@ -16,7 +16,9 @@ s390x:
 - rhel-8-for-s390x-baseos-rpms
 - rhel-8-for-s390x-appstream-rpms
 - rhocp-4.4-for-rhel-8-s390x-rpms
+- openj9-1-for-rhel-8-s390x-rpms
 ppc64le:
 - rhel-8-for-ppc64le-baseos-rpms
 - rhel-8-for-ppc64le-appstream-rpms
 - rhocp-4.4-for-rhel-8-ppc64le-rpms
+- openj9-1-for-rhel-8-ppc64le-rpms 

--- a/codeready-workspaces-plugin-java8-openj9/get-sources-jenkins.sh
+++ b/codeready-workspaces-plugin-java8-openj9/get-sources-jenkins.sh
@@ -9,6 +9,7 @@ doRhpkgContainerBuild=1
 forceBuild=0
 forcePull=0
 generateDockerfileLABELs=1
+targetFlag=""
 
 while [[ "$#" -gt 0 ]]; do
   case $1 in
@@ -39,15 +40,11 @@ if [ -z "$JOB_BRANCH" ] ; then
 		log "[ERROR] JOB_BRANCH was not specified"
 		exit 1
 fi
-if [[ ! ${targetFlag} ]]; then
-	targetFlag="--target crw-${JOB_BRANCH}-openj9-rhel-8-containers-candidate" # required for resolving openj9 artifacts 
-fi
-
 UPSTREAM_JOB_NAME="crw-deprecated_${JOB_BRANCH}" # eg., 2.4
 jenkinsURL="https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/${UPSTREAM_JOB_NAME}"
-if [[ ! ${targetFlag} ]]; then
-	targetFlag="--target crw-${JOB_BRANCH}-openj9-rhel-8-containers-candidate" # required for resolving openj9 artifacts 
-fi
+# if [[ ! ${targetFlag} ]]; then
+# 	targetFlag="--target crw-${JOB_BRANCH}-openj9-rhel-8-containers-candidate" # required for resolving openj9 artifacts 
+# fi
 log "[INFO] Using Brew with ${targetFlag}" 
 theTarGzs="
 lastSuccessfulBuild/artifact/codeready-workspaces-deprecated/node10/target/codeready-workspaces-stacks-language-servers-dependencies-node10-s390x.tar.gz


### PR DESCRIPTION
SPMM-2745 this could be the change that Chris was describing in order to switch to the new j9 content sets and drop the need for package-level deps

if the first commit works, we can omit the crw-JOB_BRANCH-openj9-rhel-8-containers-candidate target when building these the j9 images

Change-Id: Icb29d87a355fdb5e0dcca35666cdecd1c58a47d2
Signed-off-by: nickboldt <nboldt@redhat.com>