### PR TITLE
CRW-1298 - Upgrade default Kamel from 1.1.1 to 1.2.0

### DIFF
--- a/codeready-workspaces-plugin-kubernetes/Dockerfile
+++ b/codeready-workspaces-plugin-kubernetes/Dockerfile
@@ -16,7 +16,7 @@ FROM ubi8-minimal:8.2-349
 
 ENV \
     KUBECTL_VERSION="v1.18.9" \
-    KAMEL_VERSION="1.1.1" \
+    KAMEL_VERSION="1.2.0" \
     HOME=/home/theia
 
 ADD etc/storage.conf $HOME/.config/containers/storage.conf

--- a/codeready-workspaces-plugin-kubernetes/get-sources-jenkins.sh
+++ b/codeready-workspaces-plugin-kubernetes/get-sources-jenkins.sh
@@ -23,8 +23,8 @@ function log()
   fi
 }
 
-KUBECTL_VERSION="v1.18.9" # see https://github.com/kubernetes/kubernetes/releases/ or $(curl -s https://storage.googleapis.googleapis.com/kubernetes-release/release/stable.txt)
-KAMEL_VERSION="1.1.1" # see https://github.com/redhat-developer/codeready-workspaces-deprecated/blob/master/kamel/build.sh#L16 or https://github.com/apache/camel-k/releases
+KUBECTL_VERSION="v1.18.10" # see https://github.com/kubernetes/kubernetes/releases/ or $(curl -s https://storage.googleapis.googleapis.com/kubernetes-release/release/stable.txt)
+KAMEL_VERSION="1.2.0" # see https://github.com/redhat-developer/codeready-workspaces-deprecated/blob/master/kamel/build.sh#L16 or https://github.com/apache/camel-k/releases
 
 jenkinsURL="https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/crw-deprecated_${JOB_BRANCH}/lastSuccessfulBuild/artifact/codeready-workspaces-deprecated/kamel/target"
 


### PR DESCRIPTION
it is the default used by VS Code Extension Tooling for Apache Camel K
0.0.18

nota: this is a blind commit. I haven't a local environment to test it.

is this file needs to be updated too?
How?
https://github.com/redhat-developer/codeready-workspaces-images/blob/crw-2.5-rhel-8/codeready-workspaces-plugin-kubernetes/sources