### PR TITLE
encode SOURCE_BRANCH in the jenkinsfile,...

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,11 +5,11 @@ import groovy.transform.Field
 //   SCRATCH
 //   FORCE_BUILD
 //   REPOS
-//   SOURCE_BRANCH
 
-def List SYNC_REPOS = REPOS.tokenize(",").collect { it.trim() }
+def List SYNC_REPOS = REPOS.trim().tokenize(",").collect { it.trim() }
 def String SOURCE_REPO = "redhat-developer/codeready-workspaces-images" // source repo from which to find commits
-def DWNSTM_BRANCH = SOURCE_BRANCH // target branch in dist-git repo, eg., crw-2.5-rhel-8
+def String SOURCE_BRANCH = "crw-2.5-rhel-8" // target branch in dist-git repo, eg., crw-2.5-rhel-8
+def DWNSTM_BRANCH = SOURCE_BRANCH
 
 def OLD_SHA=""
 def NEW_SHA=""


### PR DESCRIPTION
encode SOURCE_BRANCH in the jenkinsfile, rather than the job, so it's easier to script updating it;
switch REPOS to a multiline field

Change-Id: I62d5a9dbee687013ebfd4b9899d452bb7d783708
Signed-off-by: nickboldt <nboldt@redhat.com>