### PR TITLE
Move OpenShift connector sidecar back to using odo 1.2.6

### DIFF
--- a/codeready-workspaces-plugin-openshift/Dockerfile
+++ b/codeready-workspaces-plugin-openshift/Dockerfile
@@ -15,7 +15,7 @@
 FROM ubi8-minimal:8.3-201
 
 ENV \
-    ODO_VERSION="v2.0.1" \
+    ODO_VERSION="v1.2.6" \
     KUBECTL_VERSION="v1.18.10" \
     HOME=/home/theia
 

--- a/codeready-workspaces-plugin-openshift/get-sources-jenkins.sh
+++ b/codeready-workspaces-plugin-openshift/get-sources-jenkins.sh
@@ -29,7 +29,7 @@ function log()
 # get correct version of odo from upstream
 # toolsJson="https://github.com/redhat-developer/vscode-openshift-tools/raw/master/src/tools.json"
 # curl -sSL $toolsJson -o - |   jq ".odo.platform.linux.url" -r | sed -r -e "s#.+/clients/odo/v(.+)/odo.+#\1#"
-ODO_VERSION="v2.0.1"
+ODO_VERSION="v1.2.6"
 KUBECTL_VERSION="v1.18.10" # see https://github.com/kubernetes/kubernetes/releases/ or $(curl -s https://storage.googleapis.googleapis.com/kubernetes-release/release/stable.txt)
 
 # update Dockerfile to record versions we expect


### PR DESCRIPTION
Needed for redhat-developer/codeready-workspaces/pull/376

Signed-off-by: Eric Williams <ericwill@redhat.com>