### PR TITLE
CRW-1420 Providing lombok.jar for Java plugin to be activated from a devfile

### DIFF
--- a/codeready-workspaces-plugin-java11-openj9/Dockerfile
+++ b/codeready-workspaces-plugin-java11-openj9/Dockerfile
@@ -17,6 +17,7 @@ USER root
 ENV \
     GRADLE_VERSION="6.1" \
     MAVEN_VERSION="3.6.3" \
+    LOMBOK_VERSION="1.18.18" \
     JAVA_HOME=/usr/lib/jvm/java-11-openj9 \
     PATH="/usr/lib/jvm/java-11-openj9:/opt/gradle/bin:/opt/apache-maven/bin:/usr/bin:${PATH:-/bin:/usr/bin}" \
     MANPATH="/usr/share/man:${MANPATH}" \
@@ -30,6 +31,7 @@ ENV \
 # run './get-sources-jenkins.sh --force-pull --nobuild' to generate this file, or 
 # use 'rhpkg sources' to fetch existing version from dist-git.
 COPY gradle-${GRADLE_VERSION}-bin.zip apache-maven-${MAVEN_VERSION}-bin.tar.gz /tmp/
+COPY lombok-${LOMBOK_VERSION}.jar /lombok.jar
 
 # NOTE: uncomment for local build. Must also set full registry path in FROM to registry.redhat.io
 # COPY content_sets.repo /etc/yum.repos.d/

--- a/codeready-workspaces-plugin-java11-openj9/get-sources-jenkins.sh
+++ b/codeready-workspaces-plugin-java11-openj9/get-sources-jenkins.sh
@@ -46,10 +46,13 @@ GRADLE_VERSION="6.1"
 # maven 3.5 rpm bundles JDK8 dependencies, so install 3.6 from https://maven.apache.org/download.cgi to avoid extras
 MAVEN_VERSION="3.6.3"
 
+LOMBOK_VERSION="1.18.18"
+
 # update Dockerfile to record version we expect for MAVEN_VERSION and GRADLE_VERSION
 sed Dockerfile \
 	-e "s#GRADLE_VERSION=\"\([^\"]\+\)\"#GRADLE_VERSION=\"${GRADLE_VERSION}\"#" \
 	-e "s#MAVEN_VERSION=\"\([^\"]\+\)\"#MAVEN_VERSION=\"${MAVEN_VERSION}\"#" \
+	-e "s#LOMBOK_VERSION=\"\([^\"]\+\)\"#LOMBOK_VERSION=\"${LOMBOK_VERSION}\"#" \
 	> Dockerfile.2
 
 # pull maven (if not present, or forced, or new version in dockerfile)
@@ -57,10 +60,11 @@ if [[ ! -f apache-maven-${MAVEN_VERSION}-bin.tar.gz ]] || [[ $(diff -U 0 --suppr
 	mv -f Dockerfile.2 Dockerfile
 	curl -sSL -O https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip
 	curl -sSL -O http://mirror.csclub.uwaterloo.ca/apache/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
-	log "[INFO] Upload new sources: gradle-${GRADLE_VERSION}-bin.zip apache-maven-${MAVEN_VERSION}-bin.tar.gz"
-	rhpkg new-sources gradle-${GRADLE_VERSION}-bin.zip apache-maven-${MAVEN_VERSION}-bin.tar.gz
+	curl -sSL -O https://projectlombok.org/downloads/lombok-${LOMBOK_VERSION}.jar
+	log "[INFO] Upload new sources: gradle-${GRADLE_VERSION}-bin.zip apache-maven-${MAVEN_VERSION}-bin.tar.gz lombok-${LOMBOK_VERSION}.jar"
+	rhpkg new-sources gradle-${GRADLE_VERSION}-bin.zip apache-maven-${MAVEN_VERSION}-bin.tar.gz lombok-${LOMBOK_VERSION}.jar
 	log "[INFO] Commit new sources"
-	COMMIT_MSG="${COMMIT_MSG}Gradle ${GRADLE_VERSION}, Maven ${MAVEN_VERSION}"
+	COMMIT_MSG="${COMMIT_MSG}Gradle ${GRADLE_VERSION}, Maven ${MAVEN_VERSION}, Lombok ${LOMBOK_VERSION}"
 	if [[ $(git commit -s -m "[get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]]; then 
 		log "[INFO] No new sources, so nothing to build."
 	elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then

--- a/codeready-workspaces-plugin-java11/Dockerfile
+++ b/codeready-workspaces-plugin-java11/Dockerfile
@@ -17,6 +17,7 @@ USER root
 ENV \
     GRADLE_VERSION="6.1" \
     MAVEN_VERSION="3.6.3" \
+    LOMBOK_VERSION="1.18.18" \
     JAVA_HOME=/usr/lib/jvm/java-11-openjdk \
     PATH="/usr/lib/jvm/java-11-openjdk:/opt/gradle/bin:/opt/apache-maven/bin:/usr/bin:${PATH:-/bin:/usr/bin}" \
     MANPATH="/usr/share/man:${MANPATH}" \
@@ -30,6 +31,7 @@ ENV \
 # run './get-sources-jenkins.sh --force-pull --nobuild' to generate this file, or 
 # use 'rhpkg sources' to fetch existing version from dist-git.
 COPY gradle-${GRADLE_VERSION}-bin.zip apache-maven-${MAVEN_VERSION}-bin.tar.gz /tmp/
+COPY lombok-${LOMBOK_VERSION}.jar /lombok.jar
 
 # NOTE: uncomment for local build. Must also set full registry path in FROM to registry.redhat.io
 # COPY content_sets.repo /etc/yum.repos.d/

--- a/codeready-workspaces-plugin-java11/get-sources-jenkins.sh
+++ b/codeready-workspaces-plugin-java11/get-sources-jenkins.sh
@@ -44,10 +44,13 @@ GRADLE_VERSION="6.1"
 # maven 3.5 rpm bundles JDK8 dependencies, so install 3.6 from https://maven.apache.org/download.cgi to avoid extras
 MAVEN_VERSION="3.6.3"
 
+LOMBOK_VERSION="1.18.18"
+
 # update Dockerfile to record version we expect for MAVEN_VERSION and GRADLE_VERSION
 sed Dockerfile \
 	-e "s#GRADLE_VERSION=\"\([^\"]\+\)\"#GRADLE_VERSION=\"${GRADLE_VERSION}\"#" \
 	-e "s#MAVEN_VERSION=\"\([^\"]\+\)\"#MAVEN_VERSION=\"${MAVEN_VERSION}\"#" \
+	-e "s#LOMBOK_VERSION=\"\([^\"]\+\)\"#LOMBOK_VERSION=\"${LOMBOK_VERSION}\"#" \
 	> Dockerfile.2
 
 # pull maven (if not present, or forced, or new version in dockerfile)
@@ -55,10 +58,11 @@ if [[ ! -f apache-maven-${MAVEN_VERSION}-bin.tar.gz ]] || [[ $(diff -U 0 --suppr
 	mv -f Dockerfile.2 Dockerfile
 	curl -sSL -O https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip
 	curl -sSL -O http://mirror.csclub.uwaterloo.ca/apache/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
-	log "[INFO] Upload new sources: gradle-${GRADLE_VERSION}-bin.zip apache-maven-${MAVEN_VERSION}-bin.tar.gz"
-	rhpkg new-sources gradle-${GRADLE_VERSION}-bin.zip apache-maven-${MAVEN_VERSION}-bin.tar.gz
+	curl -sSL -O https://projectlombok.org/downloads/lombok-${LOMBOK_VERSION}.jar
+	log "[INFO] Upload new sources: gradle-${GRADLE_VERSION}-bin.zip apache-maven-${MAVEN_VERSION}-bin.tar.gz lombok-${LOMBOK_VERSION}.jar"
+	rhpkg new-sources gradle-${GRADLE_VERSION}-bin.zip apache-maven-${MAVEN_VERSION}-bin.tar.gz lombok-${LOMBOK_VERSION}.jar
 	log "[INFO] Commit new sources"
-	COMMIT_MSG="${COMMIT_MSG}Gradle ${GRADLE_VERSION}, Maven ${MAVEN_VERSION}"
+	COMMIT_MSG="${COMMIT_MSG}Gradle ${GRADLE_VERSION}, Maven ${MAVEN_VERSION}, Lombok ${LOMBOK_VERSION}"
 	if [[ $(git commit -s -m "[get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]]; then 
 		log "[INFO] No new sources, so nothing to build."
 	elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then

--- a/codeready-workspaces-plugin-java8-openj9/Dockerfile
+++ b/codeready-workspaces-plugin-java8-openj9/Dockerfile
@@ -17,6 +17,7 @@ USER root
 ENV HOME=/home/jboss \
     NODEJS_VERSION=12 \
     MAVEN_VERSION="3.6.3" \
+    LOMBOK_VERSION="1.18.18" \
     PYTHON_VERSION="3.8" \
     JAVA_HOME=/usr/lib/jvm/java-1.8.0-openj9 \
     PATH=$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:/opt/app-root/src/.npm-global/bin/:/usr/lib/jvm/java-1.8.0-openj9:/opt/apache-maven/bin:/usr/bin:$PATH \
@@ -28,6 +29,7 @@ ENV HOME=/home/jboss \
 
 # built in Brew, use get-sources-jenkins.sh to pull latest
 COPY . /tmp/assets/
+COPY lombok-${LOMBOK_VERSION}.jar /lombok.jar
 
 # NOTE: uncomment for local build. Must also set full registry path in FROM to registry.redhat.io
 # COPY content_set*.repo /etc/yum.repos.d/

--- a/codeready-workspaces-plugin-java8-openj9/get-sources-jenkins.sh
+++ b/codeready-workspaces-plugin-java8-openj9/get-sources-jenkins.sh
@@ -76,6 +76,8 @@ lastSuccessfulURL="${jenkinsURL}/lastSuccessfulBuild/api/xml?xpath=/workflowRun/
 # maven - install 3.6 from https://maven.apache.org/download.cgi
 MAVEN_VERSION="3.6.3"
 
+LOMBOK_VERSION="1.18.18"
+
 LABELs=""
 function addLabel () {
 	addLabeln "${1}" "${2}" "${3}"
@@ -182,14 +184,16 @@ done
 # update Dockerfile to record version we expect for MAVEN_VERSION
 sed Dockerfile \
 	-e "s#MAVEN_VERSION=\"\([^\"]\+\)\"#MAVEN_VERSION=\"${MAVEN_VERSION}\"#" \
+	-e "s#LOMBOK_VERSION=\"\([^\"]\+\)\"#LOMBOK_VERSION=\"${LOMBOK_VERSION}\"#" \
 	> Dockerfile.2
 
 # pull maven (if not present, or forced, or new version in dockerfile)
 if [[ ! -f apache-maven-${MAVEN_VERSION}-bin.tar.gz ]] || [[ $(diff -U 0 --suppress-common-lines -b Dockerfile.2 Dockerfile) ]] || [[ ${forcePull} -eq 1 ]]; then
 	mv -f Dockerfile.2 Dockerfile
 	curl -sSL -O http://mirror.csclub.uwaterloo.ca/apache/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
+	curl -sSL -O https://projectlombok.org/downloads/lombok-${LOMBOK_VERSION}.jar
 fi
-outputFiles="apache-maven-${MAVEN_VERSION}-bin.tar.gz ${outputFiles}"
+outputFiles="apache-maven-${MAVEN_VERSION}-bin.tar.gz lombok-${LOMBOK_VERSION}.jar ${outputFiles}"
 
 if [[ ${outputFiles} ]]; then
 	log "[INFO] Upload new sources:${outputFiles}"

--- a/codeready-workspaces-plugin-java8/Dockerfile
+++ b/codeready-workspaces-plugin-java8/Dockerfile
@@ -17,6 +17,7 @@ USER root
 ENV HOME=/home/jboss \
     NODEJS_VERSION=12 \
     MAVEN_VERSION="3.6.3" \
+    LOMBOK_VERSION="1.18.18" \
     PYTHON_VERSION="3.8" \
     JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk \
     PATH=$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:/opt/app-root/src/.npm-global/bin/:/usr/lib/jvm/java-1.8.0-openjdk:/opt/apache-maven/bin:/usr/bin:$PATH \
@@ -24,10 +25,11 @@ ENV HOME=/home/jboss \
     JAVACONFDIRS="/etc/java${JAVACONFDIRS:+:}${JAVACONFDIRS:-}" \
     XDG_CONFIG_DIRS="/etc/xdg:${XDG_CONFIG_DIRS:-/etc/xdg}" \
     XDG_DATA_DIRS="/usr/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}" \
-    M2_HOME="/opt/apache-maven" 
+    M2_HOME="/opt/apache-maven"
 
 # built in Brew, use get-sources-jenkins.sh to pull latest
 COPY . /tmp/assets/
+COPY lombok-${LOMBOK_VERSION}.jar /lombok.jar
 
 # NOTE: uncomment for local build. Must also set full registry path in FROM to registry.redhat.io
 # COPY content_set*.repo /etc/yum.repos.d/

--- a/codeready-workspaces-plugin-java8/get-sources-jenkins.sh
+++ b/codeready-workspaces-plugin-java8/get-sources-jenkins.sh
@@ -71,6 +71,8 @@ lastSuccessfulURL="${jenkinsURL}/lastSuccessfulBuild/api/xml?xpath=/workflowRun/
 # maven - install 3.6 from https://maven.apache.org/download.cgi
 MAVEN_VERSION="3.6.3"
 
+LOMBOK_VERSION="1.18.18"
+
 LABELs=""
 function addLabel () {
 	addLabeln "${1}" "${2}" "${3}"
@@ -177,14 +179,16 @@ done
 # update Dockerfile to record version we expect for MAVEN_VERSION
 sed Dockerfile \
 	-e "s#MAVEN_VERSION=\"\([^\"]\+\)\"#MAVEN_VERSION=\"${MAVEN_VERSION}\"#" \
+	-e "s#LOMBOK_VERSION=\"\([^\"]\+\)\"#LOMBOK_VERSION=\"${LOMBOK_VERSION}\"#" \
 	> Dockerfile.2
 
 # pull maven (if not present, or forced, or new version in dockerfile)
 if [[ ! -f apache-maven-${MAVEN_VERSION}-bin.tar.gz ]] || [[ $(diff -U 0 --suppress-common-lines -b Dockerfile.2 Dockerfile) ]] || [[ ${forcePull} -eq 1 ]]; then
 	mv -f Dockerfile.2 Dockerfile
 	curl -sSL -O http://mirror.csclub.uwaterloo.ca/apache/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
+	curl -sSL -O https://projectlombok.org/downloads/lombok-${LOMBOK_VERSION}.jar
 fi
-outputFiles="apache-maven-${MAVEN_VERSION}-bin.tar.gz ${outputFiles}"
+outputFiles="apache-maven-${MAVEN_VERSION}-bin.tar.gz lombok-${LOMBOK_VERSION}.jar ${outputFiles}"
 
 if [[ ${outputFiles} ]]; then
 	log "[INFO] Upload new sources:${outputFiles}"


### PR DESCRIPTION
Providing lombok.jar to be activated from a devfile:

```yaml
  - id: redhat/java11/latest
    preferences:
      java.jdt.ls.vmargs: '-javaagent:/lombok.jar'
```

Reference issue: https://issues.redhat.com/browse/CRW-1420

Tested java11 plugin with this devfile in devsandbox (would only work in devsandbox as I have hardcoded the extension urls to devsandbox plugin registry):
```yaml
apiVersion: 1.0.0
metadata:
  generateName: java-lombok-
projects:
  - name: lombok-project-example
    source:
      location: 'https://github.com/chuucks/LOMBOK-PROJECT-EXAMPLE'
      type: git
      branch: master
components:
  - preferences:
      java.jdt.ls.vmargs: '-javaagent:/lombok.jar'
      java.server.launchMode: Standard
    type: chePlugin
    reference: 'https://gist.github.com/sunix/6a5b8da1f15390436b5faca775391278/raw/c04ca692d6d1dc2550c79e3483227bf0249d0d66/meta.yaml'
  - id: redhat/dependency-analytics/latest
    type: chePlugin
  - mountSources: true
    memoryLimit: 512Mi
    type: dockerimage
    volumes:
      - name: m2
        containerPath: /home/jboss/.m2
    alias: maven
    image: 'registry.redhat.io/codeready-workspaces/plugin-java11-rhel8@sha256:c13f0bb5f41dfe19ae90912392afc85aa8128cd3d4f7c01131cabe8d5ae3e87a'
    env:
      - value: '-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/jboss'
        name: JAVA_OPTS
      - value: $(JAVA_OPTS)
        name: MAVEN_OPTS
commands:
  - name: maven build
    actions:
      - workdir: '${CHE_PROJECTS_ROOT}/lombok-project-example'
        type: exec
        command: mvn clean install
        component: maven

```