### PR TITLE
CRW-1335 upgrade php stack to php 7.4

### DIFF
--- a/codeready-workspaces-stacks-php/Dockerfile
+++ b/codeready-workspaces-stacks-php/Dockerfile
@@ -10,7 +10,7 @@
 #
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/php-73
-FROM ubi8/php-73:1-72.1614874890
+FROM ubi8/php-74:1-17.1614874881
 
 ENV SUMMARY="Red Hat CodeReady Workspaces - PHP Stack container" \
     DESCRIPTION="Red Hat CodeReady Workspaces - PHP Stack container" \


### PR DESCRIPTION
Part of https://issues.redhat.com/browse/CRW-1335

2 other PR are coming to complete https://issues.redhat.com/browse/CRW-1335:
- https://github.com/redhat-developer/codeready-workspaces-deprecated/pull/73
- update php-di sample project to use the latest https://github.com/crw-samples/demo/pull/2
