### PR TITLE
Copy in the yarn cache resources before yarn install in the dashboard

### DIFF
--- a/codeready-workspaces-dashboard/build/scripts/sync.sh
+++ b/codeready-workspaces-dashboard/build/scripts/sync.sh
@@ -77,6 +77,7 @@ rm -f /tmp/rsync-excludes
 sed ${TARGETDIR}/build/dockerfiles/rhel.Dockerfile -r \
     -e "s#FROM registry.redhat.io/#FROM #g" \
     -e "s#FROM registry.access.redhat.com/#FROM #g" \
+    -e "/RUN yarn install/i COPY asset-yarn-cache.tgz /tmp/\nRUN tar xzf /tmp/asset-yarn-cache.tgz -C .yarn/cache && rm -f /tmp/asset-yarn-cache.tgz" \
 > ${TARGETDIR}/Dockerfile
 cat << EOT >> ${TARGETDIR}/Dockerfile
 ENV SUMMARY="Red Hat CodeReady Workspaces dashboard container" \\


### PR DESCRIPTION
This turns:
```Dockerfile
RUN yarn install
```
inside of rhel.Dockerfile to
```Dockerfile
COPY asset-yarn-cache.tgz /tmp/
RUN tar xzf /tmp/asset-yarn-cache.tgz -C .yarn/cache && rm -f /tmp/asset-yarn-cache.tgz
RUN yarn install
```

so that all the yarn cache resources are in the image before `yarn install` is run

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>