### PR TITLE
Adapt to the new plugin registry

### DIFF
--- a/codeready-workspaces-pluginregistry/bootstrap.Dockerfile
+++ b/codeready-workspaces-pluginregistry/bootstrap.Dockerfile
@@ -1,0 +1,37 @@
+#
+# Copyright (c) 2018-2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/python-38
+FROM ubi8-python-38:1-54.1618436884 as builder
+USER 0
+
+# Keep old BOOTSTRAP variable as the rhel.install script still checks them
+ARG BOOTSTRAP=true
+ENV BOOTSTRAP=${BOOTSTRAP}
+
+# Install deps
+COPY ./build/dockerfiles/content_sets_rhel8.repo /etc/yum.repos.d/
+COPY ./build/dockerfiles/rhel.install.sh /tmp
+RUN /tmp/rhel.install.sh && rm -f /tmp/rhel.install.sh
+
+# Copy files needed for the plugin registry build/artifact creation
+COPY ./build.sh ./*.yml ./*.yaml ./*.js ./*.json ./yarn.lock /build/
+COPY ./.yarn /build/.yarn/
+COPY ./tools/ /build/tools/
+COPY ./build /build/build/
+
+# Run plugin registry build to generate artifacts
+WORKDIR /build/
+RUN SKIP_FORMAT=true SKIP_LINT=true SKIP_TEST=true ./build.sh --offline --skip-oci-image --skip-digest-generation
+
+# Archive artifacts to be copied out by Jenkins
+RUN tar -czvf resources.tgz ./output/v3/ && mkdir /tmp/resources/ && cp ./resources.tgz /tmp/resources/

--- a/codeready-workspaces-pluginregistry/build/scripts/sync.sh
+++ b/codeready-workspaces-pluginregistry/build/scripts/sync.sh
@@ -93,18 +93,7 @@ sed "${TARGETDIR}/build/dockerfiles/Dockerfile" --regexp-extended \
     -e 's|# (COPY root-local.tgz)|\1|' \
     `# only enable rhel8 here -- don't want centos or epel ` \
     -e 's|^ *(COPY .*)/content_set.*repo (.+)|\1/content_sets_rhel8.repo \2|' \
-    `# Comment out PATCHED_* args from build and disable update_devfile_patched_image_tags.sh` \
-    -e 's|^ *ARG PATCHED.*|# &|' \
-    -e '/^ *RUN TAG/,+3 s|.*|# &| ' \
-    `# Disable intermediate build targets` \
-    -e 's|^ *FROM registry AS offline-registry|# &|' \
-    -e '/^ *FROM builder AS offline-builder/,+3 s|.*|# &|' \
-    -e 's|^[^#]*--from=offline-builder.*|# &|' \
-    `# Enable cache_artifacts.sh` \
-    -e '\|swap_images.sh|i # Cache projects in CRW \
-COPY ./build/dockerfiles/rhel.cache_artifacts.sh resources.tgz /tmp/ \
-RUN /tmp/rhel.cache_artifacts.sh /build/v3/ && rm -rf /tmp/rhel.cache_artifacts.sh /tmp/resources.tgz \
-' > "${TARGETDIR}/Dockerfile"
+  > "${TARGETDIR}/Dockerfile"
 
 cat << EOT >> "${TARGETDIR}/Dockerfile"
 ENV SUMMARY="Red Hat CodeReady Workspaces pluginregistry container" \\


### PR DESCRIPTION
* Create and commit bootstrap.Dockerfile -- don't generate it with sed
* Inside bootstrap.Dockerfile we generate the plugin registry meta.yamls/artifacts without pushing an image
* Tar those up into a tar archive called resources.tgz
* Business as usual after that

Part of CRW-1648

Signed-off-by: Eric Williams <ericwill@redhat.com>