### PR TITLE
Add in newline before -mod=vendor when syncing

### DIFF
--- a/codeready-workspaces-devworkspace/build/scripts/sync.sh
+++ b/codeready-workspaces-devworkspace/build/scripts/sync.sh
@@ -90,7 +90,7 @@ sed ${TARGETDIR}/build/dockerfiles/Dockerfile -r \
     `# https://github.com/devfile/devworkspace-operator/issues/166 https://golang.org/doc/go1.13 DON'T use proxy for Brew` \
     -e "s@(RUN go env GOPROXY$)@#\1@g" \
     `# CRW-1680 use vendor folder (no internet); print commands (-x)` \
-    -e "s@(go build \\\\)@\1 -mod=vendor -x \\\\@" \
+    -e "s@(go build \\\\)@\1\n  -mod=vendor -x \\\\@" \
     -e "s/# *RUN yum /RUN yum /g" \
 > ${TARGETDIR}/Dockerfile
 cat << EOT >> ${TARGETDIR}/Dockerfile


### PR DESCRIPTION
Currently it looks like `-mod=vendor` gets added on the same line as `go build` like: `go build \ -mod=vendor -x \`. In order to get everything to build correctly `-mod=vendor` has to be on a newline. The real fix is probably for the devworkspace-che-operator to use go 1.14 though

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>