### PR TITLE
Remove -mod=vendor from sed command in devworkspace-che-operator

### DIFF
--- a/codeready-workspaces-devworkspace/build/scripts/sync.sh
+++ b/codeready-workspaces-devworkspace/build/scripts/sync.sh
@@ -90,7 +90,6 @@ sed ${TARGETDIR}/build/dockerfiles/Dockerfile -r \
     `# https://github.com/devfile/devworkspace-operator/issues/166 https://golang.org/doc/go1.13 DON'T use proxy for Brew` \
     -e "s@(RUN go env GOPROXY$)@#\1@g" \
     `# CRW-1680 use vendor folder (no internet); print commands (-x)` \
-    -e "s@(go build \\\\)@\1\n  -mod=vendor -x \\\\@" \
     -e "s/# *RUN yum /RUN yum /g" \
 > ${TARGETDIR}/Dockerfile
 cat << EOT >> ${TARGETDIR}/Dockerfile


### PR DESCRIPTION
With the adoption of go 1.14 in devworkspace-che-operator we no longer have to specify `-mod=vendor`. It should automatically pick it up as long as the vendor folder is there.

Related PR: https://github.com/che-incubator/devworkspace-che-operator/pull/44

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>
