### PR TITLE
Switch dashboard to yarn 1

### DIFF
--- a/codeready-workspaces-dashboard/build/scripts/patch-remove-pnp-plugin.diff
+++ b/codeready-workspaces-dashboard/build/scripts/patch-remove-pnp-plugin.diff
@@ -1,0 +1,25 @@
+diff --git a/codeready-workspaces-dashboard/webpack.config.common.js b/codeready-workspaces-dashboard/webpack.config.common.js
+index 87be2e40..ee585e9c 100644
+--- a/codeready-workspaces-dashboard/webpack.config.common.js
++++ b/codeready-workspaces-dashboard/webpack.config.common.js
+@@ -10,7 +10,6 @@
+  *   Red Hat, Inc. - initial API and implementation
+  */
+ 
+-const PnpPlugin = require('pnp-webpack-plugin');
+ const HtmlWebpackPlugin = require('html-webpack-plugin');
+ const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+ const stylus_plugin = require('poststylus');
+@@ -112,12 +111,8 @@ module.exports = {
+     ]
+   },
+   resolve: {
+-    plugins: [PnpPlugin],
+     extensions: ['.js', '.ts', '.tsx']
+   },
+-  resolveLoader: {
+-    plugins: [PnpPlugin.moduleLoader(module)],
+-  },
+   node: {
+     fs: 'empty',
+     net: 'empty',

--- a/codeready-workspaces-dashboard/build/scripts/sync.sh
+++ b/codeready-workspaces-dashboard/build/scripts/sync.sh
@@ -82,10 +82,10 @@ rm -f /tmp/rsync-excludes
 echo "Switching dashboard to yarn 1"
 
 # prepare node_modules with yarn 2
-echo "nodeLinker: node-modules" >> yarnrc.yml
+echo "nodeLinker: node-modules" >> .yarnrc.yml
 yarn install
 
-# # switch project to yarn 1 and regenerate yarn.lock in corresponding format
+# switch project to yarn 1 and regenerate yarn.lock in corresponding format
 pushd "${TARGETDIR}" >/dev/null
 mkdir -p .yarn2-backup/.yarn
 cp -r ./.yarn/* ./.yarn2-backup/.yarn && rm -rf ./yarn
@@ -95,13 +95,13 @@ git apply $SCRIPTS_DIR/patch-remove-pnp-plugin.diff
 popd >/dev/null
 yarn install
 
-# transform rhel.Dockefile -> Dockerfile
+# transform rhel.Dockerfile -> Dockerfile
 sed ${TARGETDIR}/build/dockerfiles/rhel.Dockerfile -r \
     `# Strip registry from image references` \
     -e 's|FROM registry.access.redhat.com/|FROM |' \
     -e 's|FROM registry.redhat.io/|FROM |' \
-	`# insert logic to unpack asset-yarn-cache.tgz into /dashboard/.yarn/cache` \
-    -e "/RUN \/dashboard\/.yarn\/releases\/yarn-\*.cjs install/i COPY asset-yarn-cache.tgz /tmp/\nRUN tar xzf /tmp/asset-yarn-cache.tgz && rm -f /tmp/asset-yarn-cache.tgz" \
+	`# insert logic to unpack asset-node-modules-cache.tgz into /dashboard/node-modules` \
+    -e "/RUN \/dashboard\/.yarn\/releases\/yarn-\*.cjs install/i COPY asset-node-modules-cache.tgz /tmp/\nRUN tar xzf /tmp/asset-node-modules-cache.tgz && rm -f /tmp/asset-node-modules-cache.tgz" \
 > ${TARGETDIR}/Dockerfile
 cat << EOT >> ${TARGETDIR}/Dockerfile
 ENV SUMMARY="Red Hat CodeReady Workspaces dashboard container" \\
@@ -124,7 +124,7 @@ EOT
 echo "Converted Dockerfile"
 
 # add ignore for the tarball in mid and downstream
-echo "/asset-yarn-cache.tgz" >> ${TARGETDIR}/.gitignore
+echo "/asset-node-modules-cache.tgz" >> ${TARGETDIR}/.gitignore
 echo "Adjusted .gitignore"
 
 # apply CRW branding styles

--- a/codeready-workspaces-dashboard/get-sources-jenkins.sh
+++ b/codeready-workspaces-dashboard/get-sources-jenkins.sh
@@ -46,10 +46,10 @@ tag=$(pwd);tag=${tag##*/}
 ${BUILDER} build . -f ${BOOTSTRAPFILE} --target builder -t ${tag}:bootstrap # --no-cache
 
 # step two - extract cache folder to tarball (let's hope there's nothing arch-specific we need here!)
-${BUILDER} run --rm --entrypoint sh ${tag}:bootstrap -c 'tar -pzcf - .yarn/cache' > "asset-yarn-cache.tgz"
+${BUILDER} run --rm --entrypoint sh ${tag}:bootstrap -c 'tar -pzcf - node-modules' > "asset-node-modules-cache.tgz"
 ${BUILDER} rmi ${tag}:bootstrap
 
-outputFiles=asset-yarn-cache.tgz
+outputFiles=asset-node-modules-cache.tgz
 if [[ ${outputFiles} ]]; then
 	log "[INFO] Upload new sources:${outputFiles}"
 	rhpkg new-sources ${outputFiles}


### PR DESCRIPTION
 Since IBM Z does not support yarn 2 yet, we're stuck with yarn 1.
Not to move upstream back, we're switching to yarn 1 during source sync.

This PR is WIP due the following TODOs:
- [x] load node_modules and everything else needed (node cache, I don't know) to lookaside cache;
- [x] adjust Dockerfile to use archive from lookaside cache;

Thanks @akurinnoy for the idea and help on preparing all the needed commands.