### PR TITLE
Patch both the dashboard rhel.Dockerfile and the root Dockerfile

### DIFF
--- a/codeready-workspaces-dashboard/build/scripts/sync.sh
+++ b/codeready-workspaces-dashboard/build/scripts/sync.sh
@@ -100,6 +100,9 @@ rm -fr ${TARGETDIR}/node_modules/
 rm -fr ${TARGETDIR}/.yarn/cache
 rm -fr ${TARGETDIR}/.yarn2-backup/.yarn/cache
 
+# .yarnrc.yml won't exist while we're still building with yarn 1 so we will have to remove it temporarily
+sed -i 's|COPY .yarnrc.yml /dashboard/||' ${TARGETDIR}/build/dockerfiles/rhel.Dockerfile
+
 # transform rhel.Dockerfile -> Dockerfile
 sed ${TARGETDIR}/build/dockerfiles/rhel.Dockerfile -r \
     `# Strip registry from image references` \
@@ -107,8 +110,6 @@ sed ${TARGETDIR}/build/dockerfiles/rhel.Dockerfile -r \
     -e 's|FROM registry.redhat.io/|FROM |' \
     `# insert logic to unpack asset-node-modules-cache.tgz into /dashboard/node-modules` \
     -e "/RUN \/dashboard\/.yarn\/releases\/yarn-\*.cjs install/i COPY asset-node-modules-cache.tgz /tmp/\nRUN tar xzf /tmp/asset-node-modules-cache.tgz && rm -f /tmp/asset-node-modules-cache.tgz" \
-    `# .yarnrc.yml won't exist while we're still building with yarn 1 so we will have to remove it temporarily` \
-    -e 's|COPY .yarnrc.yml /dashboard/||' \
 > ${TARGETDIR}/Dockerfile
 cat << EOT >> ${TARGETDIR}/Dockerfile
 ENV SUMMARY="Red Hat CodeReady Workspaces dashboard container" \\


### PR DESCRIPTION
This PR patches the rhel.Dockerfile directly so that both the rhel.Dockerfile and the root Dockerfile won't have `COPY .yarnrc.yml /dashboard/`

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>