### PR TITLE
Fix typo in propagating dashboard node_modules

### DIFF
--- a/codeready-workspaces-dashboard/get-sources-jenkins.sh
+++ b/codeready-workspaces-dashboard/get-sources-jenkins.sh
@@ -46,7 +46,7 @@ tag=$(pwd);tag=${tag##*/}
 ${BUILDER} build . -f ${BOOTSTRAPFILE} --target builder -t ${tag}:bootstrap # --no-cache
 
 # step two - extract cache folder to tarball (let's hope there's nothing arch-specific we need here!)
-${BUILDER} run --rm --entrypoint sh ${tag}:bootstrap -c 'tar -pzcf - node-modules' > "asset-node-modules-cache.tgz"
+${BUILDER} run --rm --entrypoint sh ${tag}:bootstrap -c 'tar -pzcf - node_modules' > "asset-node-modules-cache.tgz"
 ${BUILDER} rmi ${tag}:bootstrap
 
 outputFiles=asset-node-modules-cache.tgz


### PR DESCRIPTION
Fix typo in propagating dashboard node_modules.

The example of failure that happened due this mistake:
https://main-jenkins-csb-crwqe.apps.ocp4.prod.psi.redhat.com/job/CRW_CI/job/sync-to-downstream_2.x/170/console

> 15:29:33 STEP 12: COMMIT codeready-workspaces-dashboard:bootstrap
15:30:41 5d86210d66e4bf2b5d8df0fc06064254656aa0ec969bcbecde1586535ba0f8ec
15:30:49 + /usr/bin/podman run --rm --entrypoint sh codeready-workspaces-dashboard:bootstrap -c 'tar -pzcf - node-modules'
15:30:49 tar: node-modules: Cannot stat: No such file or directory
15:30:49 tar: Exiting with failure status due to previous errors