### PR TITLE
fix: No longer pin the devworkspace-client to a specific version

### DIFF
--- a/codeready-workspaces-dashboard/build/scripts/sync.sh
+++ b/codeready-workspaces-dashboard/build/scripts/sync.sh
@@ -89,10 +89,6 @@ git apply $SCRIPTS_DIR/patch-remove-pnp-plugin.diff
 popd >/dev/null
 yarn install
 
-# Dashboard requires a very specific version of the devworkspace-client
-# we can't just rely on the one that the regenerated yarn.lock file gives us
-yarn add @eclipse-che/devworkspace-client@0.0.1-1619438984
-
 # Remove all the dependencies since they aren't actually needed
 rm -fr ${TARGETDIR}/node_modules/
 rm -fr ${TARGETDIR}/.yarn/cache


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>