### PR TITLE
fix: improved handling for devworkspace controller dockerfile

### DIFF
--- a/codeready-workspaces-devworkspace-controller/build/scripts/sync.sh
+++ b/codeready-workspaces-devworkspace-controller/build/scripts/sync.sh
@@ -95,10 +95,10 @@ sed ${TARGETDIR}/build/Dockerfile -r \
     `# more replacements` \
     -e "s#FROM registry.redhat.io/#FROM #g" \
     -e "s#FROM registry.access.redhat.com/#FROM #g" \
-    -e "s/(RUN go mod download$)/#\1/g" \
+    -e "s/(go mod download$)/#\1/g" \
     -e "s/(RUN go mod tidy)/#\1/g" \
     `# https://github.com/devfile/devworkspace-operator/issues/166 https://golang.org/doc/go1.13 DON'T use proxy for Brew` \
-    -e "s@(RUN go env GOPROXY$)@#\1@g" \
+    -e "s@(RUN go env GOPROXY)@#\1@g" \
     `# CRW-1680 use vendor folder (no internet); print commands (-x)` \
     -e "s@(go build \\\\)@\1 -mod=vendor -x \\\\@" \
     -e "s/# *RUN yum /RUN yum /g" \


### PR DESCRIPTION
With this PR:
```
RUN go env GOPROXY && \
    go mod download
```
will get transformed into:
```
#RUN go env GOPROXY && \
    #go mod download
```

after syncing

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>