### PR TITLE
feat(python-jupyter): enabling prebuilt venv with all the dependencies to start python jupyter server

### DIFF
--- a/codeready-workspaces-plugin-java8/Dockerfile
+++ b/codeready-workspaces-plugin-java8/Dockerfile
@@ -110,6 +110,8 @@ RUN \
         cp -R /tmp/py-unpack/bin/* /usr/bin && \
         cp -R /tmp/py-unpack/lib/* /usr/lib && \
         cp -R /tmp/py-unpack/lib64/* /usr/lib64 && \
+        cp -R /tmp/py-unpack/.venv "${HOME}/.venv-tmp" && \
+        chgrp -R 0 "${HOME}/.venv-tmp" && chmod -R g+rwX "${HOME}/.venv-tmp" && \
         rm -fr /tmp/py-unpack \
     else \
         echo "[WARNING] Python lang server dependency tarball not found. Python support may be more limited on $(uname -m)"; \

--- a/codeready-workspaces-plugin-java8/entrypoint.sh
+++ b/codeready-workspaces-plugin-java8/entrypoint.sh
@@ -27,4 +27,14 @@ if ! grep -Fq "${USER_ID}" /etc/passwd; then
     sed "s/\${HOME}/\/home\/jboss/g" > /etc/group
 fi
 
+# Setup .venv in the 'venv' volume that should be mounted in HOME/.venv
+mkdir -p "${HOME}"/.venv
+if [ ! -f "${HOME}"/.venv/bin/activate ]; then
+  echo "${HOME}"/.venv is empty, moving files from "${HOME}"/.venv-tmp/
+  mv "${HOME}"/.venv-tmp/* "${HOME}"/.venv
+fi
+
+# shellcheck source=/dev/null
+source "${HOME}"/.venv/bin/activate
+
 exec "$@"


### PR DESCRIPTION
Enabling prebuilt venv with all the dependencies to start python jupyter server

to be tested with https://github.com/redhat-developer/codeready-workspaces-deprecated/pull/76 and this devfile:

```yaml
apiVersion: 1.0.0
metadata:
  generateName: python-dev-jupyter-
projects:
  - name: jupyter-hello-world1
    source:
      location: 'https://github.com/chasbecker/TextAnalysis.git'
      startPoint: master
      type: git
components:
  - id: ms-python/python/latest
    preferences:
      python.globalModuleInstallation: true
    type: chePlugin
    registryUrl: 'https://sunix-crw-plugin-registry-dev-103m5.surge.sh/v3'
  - mountSources: true
    memoryLimit: 512Mi
    type: dockerimage
    volumes:
      - name: venv
        containerPath: /home/jboss/.venv
    alias: python
    image: 'quay.io/sunix/che-plugin-sidecar:crw-java8'
  - id: eclipse/che-theia/latest
    type: cheEditor
    registryUrl: 'https://sunix-crw-plugin-registry-dev-103m5.surge.sh/v3'
commands:
  - name: set up venv with requirements
    actions:
      - workdir: /home/jboss
        type: exec
        command: python -m venv .venv && . .venv/bin/activate && python -m pip install -r /projects/jupyter-hello-world1/requirements.txt
        component: python

```
