### PR TITLE
Adapt CRW dashboard to a newer product.json.template & update request feature link

### DIFF
--- a/codeready-workspaces-dashboard/packages/dashboard-frontend/assets/branding/product.json.template
+++ b/codeready-workspaces-dashboard/packages/dashboard-frontend/assets/branding/product.json.template
@@ -4,9 +4,20 @@
   "productVersion": "@@crw.version@@",
   "logoFile": "che-logo.svg",
   "logoTextFile": "che-logo-text.svg",
-  "helpPath": "https://access.redhat.com/products/red-hat-codeready-workspaces/",
-  "helpTitle": "Support",
-  "supportEmail": "codeready-workspaces-wish@redhat.com",
+  "links": [
+    {
+      "text": "Raise feature request",
+      "href": "https://issues.redhat.com/secure/CreateIssue.jspa?pid=12321720&issuetype=2"
+    },
+    {
+      "text": "Documentation",
+      "href": "@@crw.docs.baseurl@@/"
+    },
+    {
+      "text": "Support",
+      "href": "https://access.redhat.com/products/red-hat-codeready-workspaces/"
+    },
+  ],
   "docs": {
     "devfile" : "@@crw.docs.baseurl@@/html-single/end-user_guide/index#configuring-a-workspace-using-a-devfile_crw",
     "workspace" : "@@crw.docs.baseurl@@/html-single/end-user_guide/index#workspaces-overview_crw",


### PR DESCRIPTION
Adapt CRW dashboard to a newer product.json.template from https://github.com/eclipse-che/che-dashboard/pull/294
+ update request feature link

It should fix https://issues.redhat.com/browse/CRW-1879