### PR TITLE
Fix typo in the dashboard synchronization script

### DIFF
--- a/codeready-workspaces-dashboard/build/dockerfiles/rhel.Dockerfile
+++ b/codeready-workspaces-dashboard/build/dockerfiles/rhel.Dockerfile
@@ -31,7 +31,7 @@ ENV STATIC_SERVER=packages/static-server
 COPY ${STATIC_SERVER}/package.json /dashboard/${STATIC_SERVER}/
 
 WORKDIR /dashboard
-RUN /dashboard/.yarn/releases/yarn-*.cjs install --ignore-engine
+RUN /dashboard/.yarn/releases/yarn-*.cjs install --ignore-engines
 COPY packages/ /dashboard/packages
 RUN /dashboard/.yarn/releases/yarn-*.cjs build
 

--- a/codeready-workspaces-dashboard/build/scripts/sync.sh
+++ b/codeready-workspaces-dashboard/build/scripts/sync.sh
@@ -126,8 +126,8 @@ LABEL summary="\$SUMMARY" \\
 EOT
 
 # Patch rhel.Dockerfile to switch to yarn1
-sed -r -i \
-  -e 's|(RUN /dashboard/.yarn/releases/yarn-\*\.cjs install)|\1 --ignore-engine|' \
+sed -r -i '' \
+  -e 's|(RUN /dashboard/.yarn/releases/yarn-\*\.cjs install)|\1 --ignore-engines|' \
   ${TARGETDIR}/build/dockerfiles/rhel.Dockerfile
 
 echo "Converted Dockerfile"


### PR DESCRIPTION
Fixed typo `--ignore-engine` => `--ignore-engines`