### PR TITLE
Change asset's names according to brew conventions

### DIFF
--- a/codeready-workspaces-idea/build/scripts/sync.sh
+++ b/codeready-workspaces-idea/build/scripts/sync.sh
@@ -90,10 +90,6 @@ sed_in_place -r \
   -e "s#FROM (registry.access.redhat.com|registry.redhat.io)/#FROM #g" \
   `# Remove unused Python packages (support for PyCharm not included in CRW)` \
   -e "/# Python support/d" -e "/python2 python39 \\\\/d" \
-  `# use CRW filename conventions - tarballs should start with asset- and end with a filetype` \
-  -e "s#ide-packaging#asset-ide-packaging.tgz#" \
-  -e "s#projector-server-assembly#asset-projector-server-assembly.tgz#" \
-  -e "s#static-assembly#asset-static-assembly.tgz#" \
   "${TARGETDIR}"/Dockerfile
 
 # Overwrite default configuration

--- a/codeready-workspaces-idea/get-sources.sh
+++ b/codeready-workspaces-idea/get-sources.sh
@@ -38,32 +38,26 @@ function logn()
 if [[ ${pullAssets} -eq 1 ]]; then
   ./projector.sh build --prepare --url $idePackagingUrl
 
-  if [[ ! -f "ide-packaging" ]]; then
-    log "[ERROR] 'ide-packaging' not found, so nothing to build."
+  if [[ ! -f "asset-ide-packaging.tar.gz" ]]; then
+    log "[ERROR] 'asset-ide-packaging.tar.gz' not found, so nothing to build."
     exit 1;
   fi
 
-  if [[ ! -f "projector-server-assembly" ]]; then
-    log "[ERROR] 'projector-server-assembly' not found, so nothing to build."
+  if [[ ! -f "asset-projector-server-assembly.zip" ]]; then
+    log "[ERROR] 'asset-projector-server-assembly.zip' not found, so nothing to build."
     exit 1;
   fi
 
-  if [[ ! -f "static-assembly" ]]; then
-    log "[ERROR] 'static-assembly' not found, so nothing to build."
+  if [[ ! -f "asset-static-assembly.tar.gz" ]]; then
+    log "[ERROR] 'asset-static-assembly.tar.gz' not found, so nothing to build."
     exit 1;
   fi
 
-  outputFiles="ide-packaging projector-server-assembly static-assembly"
+  outputFiles="asset-ide-packaging.tar.gz asset-projector-server-assembly.zip asset-static-assembly.tar.gz"
 fi
 
 if [[ $(git diff-index HEAD --) ]] || [[ ${pullAssets} -eq 1 ]]; then
 	git add sources Dockerfile .gitignore || true
-	outputFilesRenamed=""
-	for f in ${outputFiles}; do # rename files to be consistent with CRW conventions
-		rm -f asset-${f}.tgz; mv $f asset-${f}.tgz
-		outputFilesRenamed="${outputFilesRenamed}asset-${f}.tgz "
-	done
-	outputFiles="${outputFilesRenamed}"
 	log "[INFO] Upload new sources: ${outputFiles}"
 	# shellcheck disable=SC2086
 	rhpkg new-sources ${outputFiles}


### PR DESCRIPTION
According to rules for naming the assets which are included in Brew build, update the `sync.sh` and `get-sources.sh`.
Updated assets name available in upstream branch: https://github.com/che-incubator/jetbrains-editor-images/tree/20210728 which is based on latest released tag: https://github.com/che-incubator/jetbrains-editor-images/releases/tag/20210728.f3dcdf6

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>