### PR TITLE
Install JDK as requirement for building Projector sources

### DIFF
--- a/codeready-workspaces-idea/get-sources.sh
+++ b/codeready-workspaces-idea/get-sources.sh
@@ -36,6 +36,14 @@ function logn()
 }
 
 if [[ ${pullAssets} -eq 1 ]]; then
+  JDK_VER="11"
+  sudo yum -y install java-${JDK_VER}-openjdk java-${JDK_VER}-openjdk-devel
+  export PATH="/usr/lib/jvm/java-${JDK_VER}-openjdk:/usr/bin:${PATH}"
+  export JAVA_HOME="/usr/lib/jvm/java-${JDK_VER}-openjdk"
+
+  log "[INFO] java version:"
+  java --version
+
   ./projector.sh build --prepare --url $idePackagingUrl
 
   if [[ ! -f "asset-ide-packaging.tar.gz" ]]; then


### PR DESCRIPTION
Projector sources build using Gradle Wrapper by calling:
```
./gradlew :projector-server:distZip
```
under the hood of `./projector.sh` shell script. As a requirement, JDK 11 should be installed and `JAVA_HOME` env variable should be configured.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>