### PR TITLE
fix: Remove trailing comma from links in product.json

### DIFF
--- a/codeready-workspaces-dashboard/packages/dashboard-frontend/assets/branding/product.json
+++ b/codeready-workspaces-dashboard/packages/dashboard-frontend/assets/branding/product.json
@@ -16,7 +16,7 @@
     {
       "text": "Support",
       "href": "https://access.redhat.com/products/red-hat-codeready-workspaces/"
-    },
+    }
   ],
   "docs": {
     "devfile" : "https://access.redhat.com/documentation/en-us/red_hat_codeready_workspaces/2.12/html-single/end-user_guide/index#configuring-a-workspace-using-a-devfile_crw",

--- a/codeready-workspaces-dashboard/packages/dashboard-frontend/assets/branding/product.json.template
+++ b/codeready-workspaces-dashboard/packages/dashboard-frontend/assets/branding/product.json.template
@@ -16,7 +16,7 @@
     {
       "text": "Support",
       "href": "https://access.redhat.com/products/red-hat-codeready-workspaces/"
-    },
+    }
   ],
   "docs": {
     "devfile" : "@@crw.docs.baseurl@@/html-single/end-user_guide/index#configuring-a-workspace-using-a-devfile_crw",


### PR DESCRIPTION
This PR removes the trailing comma from links in product.json. This seems to fix https://issues.redhat.com/browse/CRW-2176

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>