### PR TITLE
fix: Enable devWorkspace by default in `tech-preview-*` channel and deprecate from `latest` channel

### DIFF
--- a/codeready-workspaces-operator-bundle/build/scripts/sync-che-olm-to-crw-olm.sh
+++ b/codeready-workspaces-operator-bundle/build/scripts/sync-che-olm-to-crw-olm.sh
@@ -259,16 +259,16 @@ for CSVFILE in ${TARGETDIR}/manifests/codeready-workspaces.csv.yaml; do
 	fi
 
 	# Change the install Mode to AllNamespaces by default
-    yq -Yi '.spec.installModes[] |= if .type=="OwnNamespace" then .supported |= false else . end' "${CSVFILE}"
-    yq -Yi '.spec.installModes[] |= if .type=="SingleNamespace" then .supported |= false else . end' "${CSVFILE}"
-    yq -Yi '.spec.installModes[] |= if .type=="MultiNamespace" then .supported |= false else . end' "${CSVFILE}"
-    yq -Yi '.spec.installModes[] |= if .type=="AllNamespaces" then .supported |= true else . end' "${CSVFILE}"
+	yq -Yi '.spec.installModes[] |= if .type=="OwnNamespace" then .supported |= false else . end' "${CSVFILE}"
+	yq -Yi '.spec.installModes[] |= if .type=="SingleNamespace" then .supported |= false else . end' "${CSVFILE}"
+	yq -Yi '.spec.installModes[] |= if .type=="MultiNamespace" then .supported |= false else . end' "${CSVFILE}"
+	yq -Yi '.spec.installModes[] |= if .type=="AllNamespaces" then .supported |= true else . end' "${CSVFILE}"
 
 	# Enable by default devWorkspace engine in `tech-preview-latest-all-namespaces`
 	CSV_CR_SAMPLES=$(yq -r ".metadata.annotations[\"alm-examples\"] | \
 			fromjson | \
 			( .[] | select(.kind == \"CheCluster\") | .spec.devWorkspace.enable) |= true" ${CSVFILE} |  sed -r 's/"/\\"/g')
-    yq -riY ".metadata.annotations[\"alm-examples\"] = \"${CSV_CR_SAMPLES}\"" ${CSVFILE}
+	yq -riY ".metadata.annotations[\"alm-examples\"] = \"${CSV_CR_SAMPLES}\"" ${CSVFILE}
 
 	# yq changes - transform env vars from Che to CRW values
 	changed="$(yq  -Y '.spec.displayName="Red Hat CodeReady Workspaces"' "${CSVFILE}")" && \

--- a/codeready-workspaces-operator-bundle/build/scripts/sync-che-olm-to-crw-olm.sh
+++ b/codeready-workspaces-operator-bundle/build/scripts/sync-che-olm-to-crw-olm.sh
@@ -87,6 +87,13 @@ if [[ ! -d "${TARGETDIR}" ]]; then usage; fi
 if [[ "${CSV_VERSION}" == "2.y.0" ]]; then usage; fi
 if [[ "${CSV_VERSION_PREV}" == "2.x.0" ]]; then usage; fi
 
+if [[ $CSV_VERSION =~ ^([0-9]+\.[0-9]+)\.([0-9]+) ]]; then # add 100 to the z digit
+  XY=${BASH_REMATCH[1]}
+  ZZ=${BASH_REMATCH[2]}; (( ZZ=ZZ+100 ));
+
+  CSV_VERSION="${XY}.${ZZ}"
+fi
+
 # see both sync-che-o*.sh scripts - need these since we're syncing to different midstream/dowstream repos
 CRW_RRIO="registry.redhat.io/codeready-workspaces"
 CRW_OPERATOR="crw-2-rhel8-operator"
@@ -275,7 +282,7 @@ for CSVFILE in ${TARGETDIR}/manifests/codeready-workspaces.csv.yaml; do
 	# see both sync-che-o*.sh scripts - need these since we're syncing to different midstream/dowstream repos
 	# yq changes - transform env vars from Che to CRW values
 	declare -A operator_replacements=(
-		["CHE_VERSION"]="${CSV_VERSION}" # set this to x.y.z version, matching the CSV
+		["CHE_VERSION"]="${CSV_VERSION}" # set this to x.y.10z version
 		["CHE_FLAVOR"]="codeready"
 		["CONSOLE_LINK_NAME"]="che" # use che, not workspaces - CRW-1078
 
@@ -326,7 +333,7 @@ for CSVFILE in ${TARGETDIR}/manifests/codeready-workspaces.csv.yaml; do
 	# insert replaces: field
 	declare -A spec_insertions=(
 		# We don't have replaces in the first version of CSV. When we release for the second time the tech-preview we need to uncomment this line!!
-		#[".spec.replaces"]="crwoperatorallnamespaces.v${CSV_VERSION}"
+		#[".spec.replaces"]="crwoperatorallnamespaces.v${CSV_VERSION_PREV}"
 		[".spec.version"]="${CSV_VERSION}"
 	)
 	for updateName in "${!spec_insertions[@]}"; do

--- a/codeready-workspaces-operator-bundle/build/scripts/sync-che-olm-to-crw-olm.sh
+++ b/codeready-workspaces-operator-bundle/build/scripts/sync-che-olm-to-crw-olm.sh
@@ -282,7 +282,7 @@ for CSVFILE in ${TARGETDIR}/manifests/codeready-workspaces.csv.yaml; do
 	# see both sync-che-o*.sh scripts - need these since we're syncing to different midstream/dowstream repos
 	# yq changes - transform env vars from Che to CRW values
 	declare -A operator_replacements=(
-		["CHE_VERSION"]="${CSV_VERSION}" # set this to x.y.10z version
+		["CHE_VERSION"]="${CSV_VERSION}" # set this to x.y.z version, matching the CSV
 		["CHE_FLAVOR"]="codeready"
 		["CONSOLE_LINK_NAME"]="che" # use che, not workspaces - CRW-1078
 

--- a/codeready-workspaces-operator-bundle/build/scripts/sync-che-olm-to-crw-olm.sh
+++ b/codeready-workspaces-operator-bundle/build/scripts/sync-che-olm-to-crw-olm.sh
@@ -192,7 +192,7 @@ for CSVFILE in ${TARGETDIR}/manifests/codeready-workspaces.csv.yaml; do
 		-e "s|Eclipse Che|CodeReady Workspaces|g" \
 		-e "s|Eclipse Foundation|Red Hat, Inc.|g" \
 		\
-		-e "s|name: .+preview-openshift.v.+|name: crwoperator.v${CSV_VERSION}-all-namespaces|g" \
+		-e "s|name: .+preview-openshift.v.+|name: crwoperatorallnamespaces.v${CSV_VERSION}|g" \
 		\
 		-e 's|Keycloak|Red Hat SSO|g' \
 		-e 's|my-keycloak|my-rhsso|' \
@@ -326,8 +326,8 @@ for CSVFILE in ${TARGETDIR}/manifests/codeready-workspaces.csv.yaml; do
 	# insert replaces: field
 	declare -A spec_insertions=(
 		# We don't have replaces in the first version of CSV. When we release for the second time the tech-preview we need to uncomment this line!!
-		#[".spec.replaces"]="crwoperator.v${CSV_VERSION_PREV}-all-namespaces"
-		[".spec.version"]="${CSV_VERSION}-all-namespaces"
+		#[".spec.replaces"]="crwoperatorallnamespaces.v${CSV_VERSION}"
+		[".spec.version"]="${CSV_VERSION}"
 	)
 	for updateName in "${!spec_insertions[@]}"; do
 		updateVal="${spec_insertions[$updateName]}"

--- a/codeready-workspaces-operator-bundle/build/scripts/sync-che-operator-to-crw-operator.sh
+++ b/codeready-workspaces-operator-bundle/build/scripts/sync-che-operator-to-crw-operator.sh
@@ -199,7 +199,7 @@ ${field}' = ['${field}'[] | if (.name == $updateName) then (.value = $updateVal)
 # see both sync-che-o*.sh scripts - need these since we're syncing to different midstream/dowstream repos
 # yq changes - transform env vars from Che to CRW values
 declare -A operator_replacements=(
-	["CHE_VERSION"]="${CSV_VERSION}" # set this to x.y.10z version, matching the CSV
+	["CHE_VERSION"]="${CSV_VERSION}" # set this to x.y.z version, matching the CSV
 	["CHE_FLAVOR"]="codeready"
 	["CONSOLE_LINK_NAME"]="che" # use che, not workspaces - CRW-1078
 

--- a/codeready-workspaces-operator-bundle/build/scripts/sync-che-operator-to-crw-operator.sh
+++ b/codeready-workspaces-operator-bundle/build/scripts/sync-che-operator-to-crw-operator.sh
@@ -57,6 +57,13 @@ done
 
 if [[ "${CSV_VERSION}" == "2.y.0" ]]; then usage; fi
 
+if [[ $CSV_VERSION =~ ^([0-9]+\.[0-9]+)\.([0-9]+) ]]; then # add 100 to the z digit
+  XY=${BASH_REMATCH[1]}
+  ZZ=${BASH_REMATCH[2]}; (( ZZ=ZZ+100 ));
+
+  CSV_VERSION="${XY}.${ZZ}"
+fi
+
 # see both sync-che-o*.sh scripts - need these since we're syncing to different midstream/dowstream repos
 CRW_RRIO="registry.redhat.io/codeready-workspaces"
 CRW_OPERATOR="crw-2-rhel8-operator"
@@ -192,7 +199,7 @@ ${field}' = ['${field}'[] | if (.name == $updateName) then (.value = $updateVal)
 # see both sync-che-o*.sh scripts - need these since we're syncing to different midstream/dowstream repos
 # yq changes - transform env vars from Che to CRW values
 declare -A operator_replacements=(
-	["CHE_VERSION"]="${CSV_VERSION}" # set this to x.y.z version, matching the CSV
+	["CHE_VERSION"]="${CSV_VERSION}" # set this to x.y.10z version, matching the CSV
 	["CHE_FLAVOR"]="codeready"
 	["CONSOLE_LINK_NAME"]="che" # use che, not workspaces - CRW-1078
 

--- a/codeready-workspaces-operator-bundle/manifests/codeready-workspaces.crd.yaml
+++ b/codeready-workspaces-operator-bundle/manifests/codeready-workspaces.crd.yaml
@@ -54,9 +54,6 @@ spec:
                   description: Configuration settings related to the Authentication
                     used by the Che installation.
                   properties:
-                    debug:
-                      description: Debug internal identity provider.
-                      type: boolean
                     externalIdentityProvider:
                       description: 'Instructs the Operator on whether or not to deploy
                         a dedicated Identity Provider (Keycloak or RH SSO instance).

--- a/codeready-workspaces-operator-bundle/manifests/codeready-workspaces.csv.yaml
+++ b/codeready-workspaces-operator-bundle/manifests/codeready-workspaces.csv.yaml
@@ -45,7 +45,7 @@ metadata:
               "externalDb": false
             },
             "devWorkspace": {
-              "enable": false
+              "enable": true
             },
             "metrics": {
               "enable": true
@@ -91,7 +91,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/redhat-developer/codeready-workspaces-operator/
     support: Red Hat
-  name: crwoperator.v2.11.0
+  name: crwoperator.v2.11.0-all-namespaces
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1276,5 +1276,4 @@ spec:
   maturity: stable
   provider:
     name: Red Hat
-  version: 2.11.0
-  replaces: crwoperator.v2.10.1
+  version: 2.11.0-all-namespaces

--- a/codeready-workspaces-operator-bundle/manifests/codeready-workspaces.csv.yaml
+++ b/codeready-workspaces-operator-bundle/manifests/codeready-workspaces.csv.yaml
@@ -91,7 +91,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/redhat-developer/codeready-workspaces-operator/
     support: Red Hat
-  name: crwoperator.v2.11.0-all-namespaces
+  name: crwoperatorallnamespaces.v2.11.100
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1276,4 +1276,4 @@ spec:
   maturity: stable
   provider:
     name: Red Hat
-  version: 2.11.0-all-namespaces
+  version: 2.11.100

--- a/codeready-workspaces-operator-bundle/manifests/codeready-workspaces.csv.yaml
+++ b/codeready-workspaces-operator-bundle/manifests/codeready-workspaces.csv.yaml
@@ -79,8 +79,8 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Developer Tools
     certified: "true"
-    containerImage: registry.redhat.io/codeready-workspaces/crw-2-rhel8-operator:2.11
-    createdAt: "2021-09-13T14:17:19+00:00"
+    containerImage: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-operator:2.12
+    createdAt: "2021-09-14T16:58:40+00:00"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
     operatorframework.io/suggested-namespace: openshift-operators
@@ -91,7 +91,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/redhat-developer/codeready-workspaces-operator/
     support: Red Hat
-  name: crwoperatorallnamespaces.v2.11.100
+  name: crwoperatorallnamespaces.v2.12.100
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -931,73 +931,143 @@ spec:
                     command:
                       - /manager
                     env:
-                      - name: WATCH_NAMESPACE
-                        valueFrom:
-                          fieldRef:
-                            fieldPath: metadata.annotations['olm.targetNamespaces']
-                      - name: POD_NAME
-                        valueFrom:
-                          fieldRef:
-                            fieldPath: metadata.name
-                      - name: OPERATOR_NAME
-                        value: codeready-operator
-                      - name: CHE_VERSION
-                        value: 2.11.0
-                      - name: RELATED_IMAGE_che_server
-                        value: registry.redhat.io/codeready-workspaces/server-rhel8:2.11
-                      - name: RELATED_IMAGE_dashboard
-                        value: registry.redhat.io/codeready-workspaces/dashboard-rhel8:2.11
-                      - name: RELATED_IMAGE_plugin_registry
-                        value: registry.redhat.io/codeready-workspaces/pluginregistry-rhel8:2.11
-                      - name: RELATED_IMAGE_devfile_registry
-                        value: registry.redhat.io/codeready-workspaces/devfileregistry-rhel8:2.11
-                      - name: RELATED_IMAGE_pvc_jobs
-                        value: registry.redhat.io/ubi8/ubi-minimal:8.4
-                      - name: RELATED_IMAGE_postgres
-                        value: registry.redhat.io/rhel8/postgresql-96:1
-                      - name: RELATED_IMAGE_keycloak
-                        value: registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4
-                      - name: RELATED_IMAGE_che_workspace_plugin_broker_metadata
-                        value: registry.redhat.io/codeready-workspaces/pluginbroker-metadata-rhel8:2.11
-                      - name: RELATED_IMAGE_che_workspace_plugin_broker_artifacts
-                        value: registry.redhat.io/codeready-workspaces/pluginbroker-artifacts-rhel8:2.11
-                      - name: RELATED_IMAGE_che_server_secure_exposer_jwt_proxy_image
-                        value: registry.redhat.io/codeready-workspaces/jwtproxy-rhel8:2.11
-                      - name: RELATED_IMAGE_single_host_gateway
-                        value: registry.redhat.io/codeready-workspaces/traefik-rhel8:2.11
-                      - name: RELATED_IMAGE_single_host_gateway_config_sidecar
-                        value: registry.redhat.io/codeready-workspaces/configbump-rhel8:2.11
-                      - name: RELATED_IMAGE_devworkspace_controller
-                        value: registry.redhat.io/devworkspace/devworkspace-rhel8-operator:0.8
-                      - name: RELATED_IMAGE_internal_rest_backup_server
-                        value: registry.redhat.io/codeready-workspaces/backup-rhel8:2.11
                       - name: CHE_FLAVOR
                         value: codeready
-                      - name: CONSOLE_LINK_NAME
-                        value: che
-                      - name: CONSOLE_LINK_DISPLAY_NAME
-                        value: CodeReady Workspaces
-                      - name: CONSOLE_LINK_SECTION
-                        value: Red Hat Applications
-                      - name: CONSOLE_LINK_IMAGE
-                        value: /dashboard/assets/branding/loader.svg
-                      - name: CHE_IDENTITY_SECRET
-                        value: che-identity-secret
                       - name: CHE_IDENTITY_POSTGRES_SECRET
                         value: che-identity-postgres-secret
+                      - name: CHE_IDENTITY_SECRET
+                        value: che-identity-secret
                       - name: CHE_POSTGRES_SECRET
                         value: che-postgres-secret
                       - name: CHE_SERVER_TRUST_STORE_CONFIGMAP_NAME
                         value: ca-certs
+                      - name: CHE_VERSION
+                        value: 2.12.100
+                      - name: CONSOLE_LINK_DISPLAY_NAME
+                        value: CodeReady Workspaces
+                      - name: CONSOLE_LINK_IMAGE
+                        value: /dashboard/assets/branding/loader.svg
+                      - name: CONSOLE_LINK_NAME
+                        value: che
+                      - name: CONSOLE_LINK_SECTION
+                        value: Red Hat Applications
                       - name: MAX_CONCURRENT_RECONCILES
                         value: "1"
-                      - name: RELATED_IMAGE_single_host_gateway_native_user_mode
-                        value: registry.redhat.io/codeready-workspaces/traefik-rhel8:2.11
+                      - name: OPERATOR_NAME
+                        value: codeready-operator
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: RELATED_IMAGE_che_server
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-server-rhel8:2.12
+                      - name: RELATED_IMAGE_che_server_secure_exposer_jwt_proxy_image
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-jwtproxy-rhel8:2.12
+                      - name: RELATED_IMAGE_che_workspace_plugin_broker_artifacts
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginbroker-artifacts-rhel8:2.12
+                      - name: RELATED_IMAGE_che_workspace_plugin_broker_metadata
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginbroker-metadata-rhel8:2.12
+                      - name: RELATED_IMAGE_codeready_workspaces_machineexec_plugin_registry_image_GIXDCMQK
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-machineexec-rhel8:2.12
+                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java11_devfile_registry_image_GIXDCMQK
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-rhel8:2.12
+                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java11_openj9_devfile_registry_image_GIXDCMQK
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8:2.12
+                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java11_openj9_plugin_registry_image_GIXDCMQK
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8:2.12
+                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java11_plugin_registry_image_GIXDCMQK
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-rhel8:2.12
+                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java11_ppc64le_devfile_registry_image_GIXDCMQK
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8:2.12
+                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java11_ppc64le_plugin_registry_image_GIXDCMQK
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8:2.12
+                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java11_s390x_devfile_registry_image_GIXDCMQK
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8:2.12
+                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java11_s390x_plugin_registry_image_GIXDCMQK
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8:2.12
+                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java8_devfile_registry_image_GIXDCMQK
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-rhel8:2.12
+                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java8_openj9_devfile_registry_image_GIXDCMQK
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8:2.12
+                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java8_openj9_plugin_registry_image_GIXDCMQK
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8:2.12
+                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java8_plugin_registry_image_GIXDCMQK
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-rhel8:2.12
+                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java8_ppc64le_devfile_registry_image_GIXDCMQK
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8:2.12
+                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java8_ppc64le_plugin_registry_image_GIXDCMQK
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8:2.12
+                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java8_s390x_devfile_registry_image_GIXDCMQK
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8:2.12
+                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java8_s390x_plugin_registry_image_GIXDCMQK
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8:2.12
+                      - name: RELATED_IMAGE_codeready_workspaces_plugin_kubernetes_plugin_registry_image_GIXDCMQK
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-kubernetes-rhel8:2.12
+                      - name: RELATED_IMAGE_codeready_workspaces_plugin_openshift_plugin_registry_image_GIXDCMQK
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-openshift-rhel8:2.12
+                      - name: RELATED_IMAGE_codeready_workspaces_stacks_cpp_devfile_registry_image_GIXDCMQK
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-cpp-rhel8:2.12
+                      - name: RELATED_IMAGE_codeready_workspaces_stacks_cpp_plugin_registry_image_GIXDCMQK
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-cpp-rhel8:2.12
+                      - name: RELATED_IMAGE_codeready_workspaces_stacks_dotnet_devfile_registry_image_GIXDCMQK
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-dotnet-rhel8:2.12
+                      - name: RELATED_IMAGE_codeready_workspaces_stacks_dotnet_plugin_registry_image_GIXDCMQK
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-dotnet-rhel8:2.12
+                      - name: RELATED_IMAGE_codeready_workspaces_stacks_golang_devfile_registry_image_GIXDCMQK
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-golang-rhel8:2.12
+                      - name: RELATED_IMAGE_codeready_workspaces_stacks_golang_plugin_registry_image_GIXDCMQK
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-golang-rhel8:2.12
+                      - name: RELATED_IMAGE_codeready_workspaces_stacks_php_devfile_registry_image_GIXDCMQK
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-php-rhel8:2.12
+                      - name: RELATED_IMAGE_codeready_workspaces_stacks_php_plugin_registry_image_GIXDCMQK
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-php-rhel8:2.12
+                      - name: RELATED_IMAGE_codeready_workspaces_theia_endpoint_plugin_registry_image_GIXDCMQK
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-theia-endpoint-rhel8:2.12
+                      - name: RELATED_IMAGE_codeready_workspaces_theia_plugin_registry_image_GIXDCMQK
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-theia-rhel8:2.12
+                      - name: RELATED_IMAGE_dashboard
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-dashboard-rhel8:2.12
+                      - name: RELATED_IMAGE_devfile_registry
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-devfileregistry-rhel8:2.12
+                      - name: RELATED_IMAGE_devworkspace_controller
+                        value: registry.redhat.io/devworkspace/devworkspace-rhel8-operator:0.8
+                      - name: RELATED_IMAGE_internal_rest_backup_server
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-backup-rhel8:2.12
+                      - name: RELATED_IMAGE_jboss_eap_7_eap74_openjdk8_openshift_rhel7_devfile_registry_image_G4XDILRQBI______
+                        value: registry.redhat.io/jboss-eap-7/eap74-openjdk8-openshift-rhel7:7.4.0
+                      - name: RELATED_IMAGE_jboss_eap_7_eap_xp3_openj9_11_openshift_devfile_registry_image_GMXDACQ_
+                        value: registry.redhat.io/jboss-eap-7/eap-xp3-openj9-11-openshift-rhel8:3.0
+                      - name: RELATED_IMAGE_jboss_eap_7_eap_xp3_openjdk11_openshift_devfile_registry_image_GMXDALJZBI______
+                        value: registry.redhat.io/jboss-eap-7/eap-xp3-openjdk11-openshift-rhel8:3.0-9
+                      - name: RELATED_IMAGE_jboss_eap_7_eap_xp3_ppc64le_11_openshift_devfile_registry_image_GMXDACQ_
+                        value: registry.redhat.io/jboss-eap-7/eap-xp3-openj9-11-openshift-rhel8:3.0
+                      - name: RELATED_IMAGE_jboss_eap_7_eap_xp3_s390x_11_openshift_devfile_registry_image_GMXDACQ_
+                        value: registry.redhat.io/jboss-eap-7/eap-xp3-openj9-11-openshift-rhel8:3.0
+                      - name: RELATED_IMAGE_keycloak
+                        value: registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4
                       - name: RELATED_IMAGE_keycloak_ppc64le
                         value: registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8:7.4
                       - name: RELATED_IMAGE_keycloak_s390x
                         value: registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8:7.4
-                    image: registry.redhat.io/codeready-workspaces/crw-2-rhel8-operator:2.11
+                      - name: RELATED_IMAGE_plugin_registry
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginregistry-rhel8:2.12
+                      - name: RELATED_IMAGE_postgres
+                        value: registry.redhat.io/rhel8/postgresql-96:1
+                      - name: RELATED_IMAGE_pvc_jobs
+                        value: registry.redhat.io/ubi8/ubi-minimal:8.4
+                      - name: RELATED_IMAGE_rhscl_mongodb_36_rhel7_devfile_registry_image_GEWTKMAK
+                        value: registry.redhat.io/rhscl/mongodb-36-rhel7:1-50
+                      - name: RELATED_IMAGE_single_host_gateway
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-traefik-rhel8:2.12
+                      - name: RELATED_IMAGE_single_host_gateway_config_sidecar
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-configbump-rhel8:2.12
+                      - name: RELATED_IMAGE_single_host_gateway_native_user_mode
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-traefik-rhel8:2.12
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                    image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-operator:2.12
                     imagePullPolicy: Always
                     livenessProbe:
                       failureThreshold: 10
@@ -1276,4 +1346,4 @@ spec:
   maturity: stable
   provider:
     name: Red Hat
-  version: 2.11.100
+  version: 2.12.100

--- a/codeready-workspaces-operator-metadata/build/scripts/sync-che-olm-to-crw-olm.sh
+++ b/codeready-workspaces-operator-metadata/build/scripts/sync-che-olm-to-crw-olm.sh
@@ -251,6 +251,11 @@ for CSVFILE in ${TARGETDIR}/manifests/codeready-workspaces.csv.yaml; do
 		echo "    ${0##*/} :: Converted (sed) ${CSVFILE}"
 	fi
 
+	# Disable by default devWorkspace engine in `latest` channel
+	CSV_CR_SAMPLES=$(yq -r ".metadata.annotations.\"alm-examples\"" "${CSVFILE}" | yq -r ".[0] | del(.spec.devWorkspace) | [.]"  | sed -r 's/"/\\"/g')
+	yq -riY ".metadata.annotations[\"alm-examples\"] = \"${CSV_CR_SAMPLES}\"" ${CSVFILE}
+    yq -Yi '.spec.customresourcedefinitions.owned[] |= (select(.name == "checlusters.org.eclipse.che").specDescriptors += [{"path":"devWorkspace", "x-descriptors": ["urn:alm:descriptor:com.tectonic.ui:hidden"]}])' "${CSVFILE}"
+
 	# yq changes - transform env vars from Che to CRW values
 	changed="$(yq  -Y '.spec.displayName="Red Hat CodeReady Workspaces"' "${CSVFILE}")" && \
 		echo "${changed}" > "${CSVFILE}"

--- a/codeready-workspaces-operator-metadata/build/scripts/sync-che-olm-to-crw-olm.sh
+++ b/codeready-workspaces-operator-metadata/build/scripts/sync-che-olm-to-crw-olm.sh
@@ -253,8 +253,8 @@ for CSVFILE in ${TARGETDIR}/manifests/codeready-workspaces.csv.yaml; do
 
 	# Disable by default devWorkspace engine in `latest` channel
 	CSV_CR_SAMPLES=$(yq -r ".metadata.annotations.\"alm-examples\"" "${CSVFILE}" | yq -r ".[0] | del(.spec.devWorkspace) | [.]"  | sed -r 's/"/\\"/g')
-    yq -riY ".metadata.annotations[\"alm-examples\"] = \"${CSV_CR_SAMPLES}\"" ${CSVFILE}
-    yq -Yi '.spec.customresourcedefinitions.owned[] |= (select(.name == "checlusters.org.eclipse.che").specDescriptors += [{"path":"devWorkspace", "x-descriptors": ["urn:alm:descriptor:com.tectonic.ui:hidden"]}])' "${CSVFILE}"
+	yq -riY ".metadata.annotations[\"alm-examples\"] = \"${CSV_CR_SAMPLES}\"" ${CSVFILE}
+	yq -Yi '.spec.customresourcedefinitions.owned[] |= (select(.name == "checlusters.org.eclipse.che").specDescriptors += [{"path":"devWorkspace", "x-descriptors": ["urn:alm:descriptor:com.tectonic.ui:hidden"]}])' "${CSVFILE}"
 
 	# yq changes - transform env vars from Che to CRW values
 	changed="$(yq  -Y '.spec.displayName="Red Hat CodeReady Workspaces"' "${CSVFILE}")" && \

--- a/codeready-workspaces-operator-metadata/build/scripts/sync-che-olm-to-crw-olm.sh
+++ b/codeready-workspaces-operator-metadata/build/scripts/sync-che-olm-to-crw-olm.sh
@@ -253,7 +253,7 @@ for CSVFILE in ${TARGETDIR}/manifests/codeready-workspaces.csv.yaml; do
 
 	# Disable by default devWorkspace engine in `latest` channel
 	CSV_CR_SAMPLES=$(yq -r ".metadata.annotations.\"alm-examples\"" "${CSVFILE}" | yq -r ".[0] | del(.spec.devWorkspace) | [.]"  | sed -r 's/"/\\"/g')
-	yq -riY ".metadata.annotations[\"alm-examples\"] = \"${CSV_CR_SAMPLES}\"" ${CSVFILE}
+    yq -riY ".metadata.annotations[\"alm-examples\"] = \"${CSV_CR_SAMPLES}\"" ${CSVFILE}
     yq -Yi '.spec.customresourcedefinitions.owned[] |= (select(.name == "checlusters.org.eclipse.che").specDescriptors += [{"path":"devWorkspace", "x-descriptors": ["urn:alm:descriptor:com.tectonic.ui:hidden"]}])' "${CSVFILE}"
 
 	# yq changes - transform env vars from Che to CRW values


### PR DESCRIPTION
It is not possible to have 2 channels with the same CSV name. I sync like in upstream adding to new channel the suffix `-all-namespaces` to CSV

Also this PR remove from Operator HUB UI the option to enable devworkspace and will be enabled by default in `tech-preview-latest-all-namespaces`

Upstream issue: https://github.com/eclipse/che/issues/20392
Signed-off-by: Flavius Lacatusu <flacatus@redhat.com>