### PR TITLE
Make ALLOW_DEVWORKSPACE_ENGINE env false in latest channel

### DIFF
--- a/codeready-workspaces-operator-metadata/build/scripts/sync-che-olm-to-crw-olm.sh
+++ b/codeready-workspaces-operator-metadata/build/scripts/sync-che-olm-to-crw-olm.sh
@@ -268,6 +268,7 @@ for CSVFILE in ${TARGETDIR}/manifests/codeready-workspaces.csv.yaml; do
 	# see both sync-che-o*.sh scripts - need these since we're syncing to different midstream/dowstream repos
 	# yq changes - transform env vars from Che to CRW values
 	declare -A operator_replacements=(
+		["ALLOW_DEVWORKSPACE_ENGINE"]="\"false"\" # disable devWorkspace engine in latest channel
 		["CHE_VERSION"]="${CSV_VERSION}" # set this to x.y.z version, matching the CSV
 		["CHE_FLAVOR"]="codeready"
 		["CONSOLE_LINK_NAME"]="che" # use che, not workspaces - CRW-1078

--- a/codeready-workspaces-operator-metadata/build/scripts/sync-che-operator-to-crw-operator.sh
+++ b/codeready-workspaces-operator-metadata/build/scripts/sync-che-operator-to-crw-operator.sh
@@ -192,6 +192,7 @@ ${field}' = ['${field}'[] | if (.name == $updateName) then (.value = $updateVal)
 # see both sync-che-o*.sh scripts - need these since we're syncing to different midstream/dowstream repos
 # yq changes - transform env vars from Che to CRW values
 declare -A operator_replacements=(
+	["ALLOW_DEVWORKSPACE_ENGINE"]="\"false"\" # disable devWorkspace engine in latest channel
 	["CHE_VERSION"]="${CSV_VERSION}" # set this to x.y.z version, matching the CSV
 	["CHE_FLAVOR"]="codeready"
 	["CONSOLE_LINK_NAME"]="che" # use che, not workspaces - CRW-1078


### PR DESCRIPTION
From https://github.com/eclipse-che/che-operator/pull/1065 we introduce a new environment which disable and enabled devworkspace engine
Signed-off-by: Flavius Lacatusu <flacatus@redhat.com>