### PR TITLE
feat(python-jupyter): enabling prebuilt venv with all the dependencies to start python jupyter server - Z&P - openj9 sidecar

### DIFF
--- a/codeready-workspaces-plugin-java8-openj9/Dockerfile
+++ b/codeready-workspaces-plugin-java8-openj9/Dockerfile
@@ -25,7 +25,7 @@ ENV HOME=/home/jboss \
     JAVACONFDIRS="/etc/java${JAVACONFDIRS:+:}${JAVACONFDIRS:-}" \
     XDG_CONFIG_DIRS="/etc/xdg:${XDG_CONFIG_DIRS:-/etc/xdg}" \
     XDG_DATA_DIRS="/usr/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}" \
-    M2_HOME="/opt/apache-maven" 
+    M2_HOME="/opt/apache-maven"
 
 # built in Brew, use get-sources-jenkins.sh to pull latest
 COPY . /tmp/assets/
@@ -112,6 +112,8 @@ RUN \
         cp -R /tmp/py-unpack/bin/* /usr/bin && \
         cp -R /tmp/py-unpack/lib/* /usr/lib && \
         cp -R /tmp/py-unpack/lib64/* /usr/lib64 && \
+        cp -R /tmp/py-unpack/.venv "${HOME}/.venv-tmp" && \
+        chgrp -R 0 "${HOME}/.venv-tmp" && chmod -R g+rwX "${HOME}/.venv-tmp" && \
         rm -fr /tmp/py-unpack \
     else \
         echo "[WARNING] Python lang server dependency tarball not found. Python support may be more limited on $(uname -m)"; \

--- a/codeready-workspaces-plugin-java8-openj9/entrypoint.sh
+++ b/codeready-workspaces-plugin-java8-openj9/entrypoint.sh
@@ -27,4 +27,14 @@ if ! grep -Fq "${USER_ID}" /etc/passwd; then
     sed "s/\${HOME}/\/home\/jboss/g" > /etc/group
 fi
 
+# Setup .venv in the 'venv' volume that should be mounted in HOME/.venv
+mkdir -p "${HOME}"/.venv
+if [ ! -f "${HOME}"/.venv/bin/activate ]; then
+  echo "${HOME}"/.venv is empty, moving files from "${HOME}"/.venv-tmp/
+  mv "${HOME}"/.venv-tmp/* "${HOME}"/.venv
+fi
+
+# shellcheck source=/dev/null
+source "${HOME}"/.venv/bin/activate
+
 exec "$@"


### PR DESCRIPTION
Signed-off-by: Sun Seng David TAN <sutan@redhat.com>

Applying https://github.com/redhat-developer/codeready-workspaces-images/pull/51/files for Z&P/openj9 sidecar
