### PR TITLE
fix: change the way we install yarn in .yarn/releases

### DIFF
--- a/codeready-workspaces-dashboard/build/scripts/sync.sh
+++ b/codeready-workspaces-dashboard/build/scripts/sync.sh
@@ -90,9 +90,9 @@ configjson=$(curl -sSLo- https://raw.githubusercontent.com/redhat-developer/code
 YARN_VERSION=$(echo "${configjson}" | jq -r --arg CRW_VERSION "${CRW_VERSION}" '.Other["YARN_VERSION"][$CRW_VERSION]');
 YARN_TARGET_DIR=${TARGETDIR}/.yarn/releases
 echo "Install Yarn $YARN_VERSION into $YARN_TARGET_DIR ... "
-mkdir -p ${YARN_TARGET_DIR}
-curl -L https://github.com/yarnpkg/yarn/releases/download/v${YARN_VERSION}/yarn-${YARN_VERSION}.js -o ${YARN_TARGET_DIR}/yarn-${YARN_VERSION}.js
-chmod +x ${YARN_TARGET_DIR}/yarn-${YARN_VERSION}.js
+mkdir -p "${YARN_TARGET_DIR}"
+curl -L "https://github.com/yarnpkg/yarn/releases/download/v${YARN_VERSION}/yarn-${YARN_VERSION}.js" -o "${YARN_TARGET_DIR}/yarn-${YARN_VERSION}.js"
+chmod +x "${YARN_TARGET_DIR}/yarn-${YARN_VERSION}.js"
 
 pushd "${TARGETDIR}" >/dev/null
 

--- a/codeready-workspaces-dashboard/build/scripts/sync.sh
+++ b/codeready-workspaces-dashboard/build/scripts/sync.sh
@@ -88,8 +88,11 @@ fi
 # echo "Load https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/${SCRIPTS_BRANCH}/dependencies/job-config.json [3]"
 configjson=$(curl -sSLo- https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/${SCRIPTS_BRANCH}/dependencies/job-config.json)
 YARN_VERSION=$(echo "${configjson}" | jq -r --arg CRW_VERSION "${CRW_VERSION}" '.Other["YARN_VERSION"][$CRW_VERSION]');
-echo "Install Yarn $YARN_VERSION into .yarn/ ... "
-yarn policies set-version ${YARN_VERSION}
+YARN_TARGET_DIR=${TARGETDIR}/.yarn/releases
+echo "Install Yarn $YARN_VERSION into $YARN_TARGET_DIR ... "
+mkdir -p ${YARN_TARGET_DIR}
+curl -L https://github.com/yarnpkg/yarn/releases/download/v${YARN_VERSION}/yarn-${YARN_VERSION}.js -o ${YARN_TARGET_DIR}/yarn-${YARN_VERSION}.js
+chmod +x ${YARN_TARGET_DIR}/yarn-${YARN_VERSION}.js
 
 pushd "${TARGETDIR}" >/dev/null
 


### PR DESCRIPTION
We can't use set-policies anymore since it relies
on an ability to set GitHub token as query param
while header now is required.
See for more details https://github.com/yarnpkg/yarn/issues/7847

it's actually backport of what was done against crw-2.12 branch:
https://github.com/redhat-developer/codeready-workspaces-images/pull/106
https://github.com/redhat-developer/codeready-workspaces-images/pull/107