### PR TITLE
fix: prevent op-metadata sync from needlessly updating createdAt'

### DIFF
--- a/codeready-workspaces-operator-metadata/build/scripts/sync-che-olm-to-crw-olm.sh
+++ b/codeready-workspaces-operator-metadata/build/scripts/sync-che-olm-to-crw-olm.sh
@@ -363,12 +363,9 @@ cp "${TARGETDIR}/bundle/${OLM_CHANNEL}/eclipse-che-preview-openshift/manifests/o
 cp "${TARGETDIR}/bundle/${OLM_CHANNEL}/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusterrestores.yaml" "${TARGETDIR}/manifests/codeready-workspaces-restore.crd.yaml"
 
 # date in CSV will be updated only if there were any changes in CSV
-if [[ git status --porcelain | grep "M ${CSVFILE}"]];
-	NOW="$(date -u +%FT%T+00:00)"
+if [[ $(git status --porcelain | grep "M ${CSVFILE}") ]]; then
 	echo "Changes detected, updating the date in CSV file"
-	sed -r -e "s|createdAt:.+|createdAt: \"${NOW}\"|" -i "${CSVFILE}"
-else
-	echo "No changes detected, CSV date  will not be updated"
+	sed -r -e "s|createdAt:.+|createdAt: \"$(date -u +%FT%T+00:00)\"|" -i "${CSVFILE}"
 fi
 
 popd >/dev/null || exit

--- a/codeready-workspaces-operator-metadata/build/scripts/sync-che-olm-to-crw-olm.sh
+++ b/codeready-workspaces-operator-metadata/build/scripts/sync-che-olm-to-crw-olm.sh
@@ -198,7 +198,6 @@ for CSVFILE in ${TARGETDIR}/manifests/codeready-workspaces.csv.yaml; do
 		-e 's|my-keycloak|my-rhsso|' \
 		\
 		-e "s|    - base64data: .+|${ICON}|" \
-		-e "s|createdAt:.+|createdAt: \"${NOW}\"|" \
 		\
 		-e 's|email: dfestal@redhat.com|email: nboldt@redhat.com|' \
 		-e 's|name: David Festal|name: Nick Boldt|' \
@@ -363,5 +362,13 @@ cp "${TARGETDIR}/bundle/${OLM_CHANNEL}/eclipse-che-preview-openshift/manifests/o
 cp "${TARGETDIR}/bundle/${OLM_CHANNEL}/eclipse-che-preview-openshift/manifests/org.eclipse.che_chebackupserverconfigurations.yaml" "${TARGETDIR}/manifests/codeready-workspaces-backup-server-config.crd.yaml"
 cp "${TARGETDIR}/bundle/${OLM_CHANNEL}/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusterbackups.yaml" "${TARGETDIR}/manifests/codeready-workspaces-backup.crd.yaml"
 cp "${TARGETDIR}/bundle/${OLM_CHANNEL}/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusterrestores.yaml" "${TARGETDIR}/manifests/codeready-workspaces-restore.crd.yaml"
+
+# date in CSV will be updated only if there were any changes in CSV
+if [[ git status --porcelain ]];
+	echo "Changes detected, updating the date in CSV file"
+	sed -r -e "s|createdAt:.+|createdAt: \"${NOW}\"|" -i "${CSVFILE}"
+else
+	echo "No changes detected, CSV date  will not be updated"
+fi
 
 popd >/dev/null || exit

--- a/codeready-workspaces-operator-metadata/build/scripts/sync-che-olm-to-crw-olm.sh
+++ b/codeready-workspaces-operator-metadata/build/scripts/sync-che-olm-to-crw-olm.sh
@@ -179,7 +179,6 @@ ICON="$(cat "${SCRIPTS_DIR}/sync-che-olm-to-crw-olm.icon.txt")"
 for CSVFILE in ${TARGETDIR}/manifests/codeready-workspaces.csv.yaml; do
 	cp "${SOURCE_CSVFILE}" "${CSVFILE}"
 	# transform resulting file
-	NOW="$(date -u +%FT%T+00:00)"
 	sed -r \
 		-e 's|certified: "false"|certified: "true"|g' \
 		-e "s|https://github.com/eclipse-che/che-operator|https://github.com/redhat-developer/codeready-workspaces-operator/|g" \
@@ -364,7 +363,8 @@ cp "${TARGETDIR}/bundle/${OLM_CHANNEL}/eclipse-che-preview-openshift/manifests/o
 cp "${TARGETDIR}/bundle/${OLM_CHANNEL}/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusterrestores.yaml" "${TARGETDIR}/manifests/codeready-workspaces-restore.crd.yaml"
 
 # date in CSV will be updated only if there were any changes in CSV
-if [[ git status --porcelain ]];
+if [[ git status --porcelain | grep "M ${CSVFILE}"]];
+	NOW="$(date -u +%FT%T+00:00)"
 	echo "Changes detected, updating the date in CSV file"
 	sed -r -e "s|createdAt:.+|createdAt: \"${NOW}\"|" -i "${CSVFILE}"
 else


### PR DESCRIPTION
CSV date will be updated, only if there were actual changes after the sync. This will prevent spam of syncing, where only date is being updated

Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>