### PR TITLE
fix: CRW-1157 no longer need to force...

### DIFF
--- a/codeready-workspaces-devfileregistry/build/scripts/sync.sh
+++ b/codeready-workspaces-devfileregistry/build/scripts/sync.sh
@@ -97,8 +97,7 @@ sed "${TARGETDIR}/build/dockerfiles/Dockerfile" --regexp-extended \
     `# Strip registry from image references` \
     -e 's|FROM registry.access.redhat.com/|FROM |' \
     -e 's|FROM registry.redhat.io/|FROM |' \
-    `# Set arg options: enable USE_DIGESTS and disable BOOTSTRAP; update CRW_BRANCH to correct value` \
-    -e 's|ARG USE_DIGESTS=.*|ARG USE_DIGESTS=true|' \
+    `# Set arg options: disable BOOTSTRAP; update CRW_BRANCH to correct value` \
     -e 's|ARG BOOTSTRAP=.*|ARG BOOTSTRAP=false|' \
     -e "s|ARG CRW_BRANCH=.*|ARG CRW_BRANCH=${CRW_BRANCH}|" \
     `# Enable offline build - copy in built binaries` \

--- a/codeready-workspaces-devfileregistry/get-sources.sh
+++ b/codeready-workspaces-devfileregistry/get-sources.sh
@@ -48,7 +48,6 @@ if [[ ${pullAssets} -eq 1 ]]; then
 	sed Dockerfile --regexp-extended \
 		-e 's|COPY (.*) resources.tgz (.*)|COPY \1 \2|' \
 		-e 's|ARG BOOTSTRAP=.*|ARG BOOTSTRAP=true|' \
-		-e 's|ARG USE_DIGESTS=.*|ARG USE_DIGESTS=false|' \
 		-e 's|^ *COPY root-local.tgz|# &|' \
 		`# replace org/container:tag with reg-proxy/rh-osbs/org-container:tag` \
 		-e "s#^FROM ([^/:]+)/([^/:]+):([^/:]+)#FROM registry-proxy.engineering.redhat.com/rh-osbs/\1-\2:\3#" \
@@ -64,7 +63,7 @@ if [[ ${pullAssets} -eq 1 ]]; then
 	echo "======= START BOOTSTRAP BUILD =======>"
 	# do not want digests in the BOOTSTRAP build so override default with false
 	${BUILDER} build -t ${tmpContainer} . --no-cache -f bootstrap.Dockerfile \
-		--target builder --build-arg BOOTSTRAP=true --build-arg USE_DIGESTS=false
+		--target builder --build-arg BOOTSTRAP=true
 	echo "<======= END BOOTSTRAP BUILD ======="
 	# update tarballs - step 2 - check old sources' tarballs
 	TARGZs="root-local.tgz resources.tgz"

--- a/codeready-workspaces-pluginregistry/build/scripts/sync.sh
+++ b/codeready-workspaces-pluginregistry/build/scripts/sync.sh
@@ -104,8 +104,7 @@ sed "${TARGETDIR}/build/dockerfiles/Dockerfile" --regexp-extended \
     `# Strip registry from image references` \
     -e 's|FROM registry.access.redhat.com/|FROM |' \
     -e 's|FROM registry.redhat.io/|FROM |' \
-    `# Set arg options: enable USE_DIGESTS and disable BOOTSTRAP; update CRW_BRANCH to correct value` \
-    -e 's|ARG USE_DIGESTS=.*|ARG USE_DIGESTS=true|' \
+    `# Set arg options: disable BOOTSTRAP; update CRW_BRANCH to correct value` \
     -e 's|ARG BOOTSTRAP=.*|ARG BOOTSTRAP=false|' \
     -e "s|ARG CRW_BRANCH=.*|ARG CRW_BRANCH=${CRW_BRANCH}|" \
     `# Enable offline build - copy in built binaries` \


### PR DESCRIPTION
### What does this PR do?

fix: CRW-1157 no longer need to force USE_DIGESTS=true as that's no longer in the dockerfiles / not used

Signed-off-by: nickboldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.