### PR TITLE
Make configbump push to gh releases

### DIFF
--- a/codeready-workspaces-configbump/build/dockerfiles/rhel.Dockerfile.extract.assets.sh
+++ b/codeready-workspaces-configbump/build/dockerfiles/rhel.Dockerfile.extract.assets.sh
@@ -36,6 +36,12 @@ pushd ${TMPDIR} >/dev/null || exit 1
     tar cvzf "${WORKSPACE}/asset-configbump-${ARCH}.tar.gz" ./
 popd >/dev/null || exit 1
 
+# upload the binary to GH
+if [[ ! -x ./uploadAssetsToGHRelease.sh ]]; then 
+    curl -sSLO "https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/${MIDSTM_BRANCH}/product/uploadAssetsToGHRelease.sh" && chmod +x uploadAssetsToGHRelease.sh
+fi
+./uploadAssetsToGHRelease.sh -v "${CSV_VERSION}" -b "${MIDSTM_BRANCH}" --prefix configbump "${WORKSPACE}/asset-configbump-${ARCH}.tar.gz"
+
  #cleanup
 ${PODMAN} rmi -f ${TMPIMG}
 rm -fr ${TMPDIR}


### PR DESCRIPTION
feat: call to uploadAssets disappeared (or perhaps never was) so adding it into the comfigbump build.