### PR TITLE
Changes from the CRW-2081-deprecated branch 

### DIFF
--- a/codeready-workspaces-backup/get-sources.sh
+++ b/codeready-workspaces-backup/get-sources.sh
@@ -5,16 +5,16 @@ verbose=1
 scratchFlag=""
 doRhpkgContainerBuild=1
 forceBuild=0
-# NOTE: pullAssets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
+# NOTE: --pull-assets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
 # here we want to collect assets during sync-to-downsteam (using get-sources.sh -n -p)
 # so that rhpkg build is simply a brew wrapper (using get-sources.sh -f)
-pullAssets=0
+PULL_ASSETS=0
 
 resticRestServerAssets=assets-rest-server.tgz
 
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
-		'-p'|'--pull-assets') pullAssets=1; shift 0;;
+		'-p'|'--pull-assets') PULL_ASSETS=1; shift 0;;
 		'-a'|'--publish-assets') exit 0; shift 0;;
 		'-d'|'--delete-assets') exit 0; shift 0;;
 		'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
@@ -31,7 +31,7 @@ function log() {
 	fi
 }
 
-if [[ ${pullAssets} -eq 1 ]]; then
+if [[ ${PULL_ASSETS} -eq 1 ]]; then
 	BUILDER=$(command -v podman || true)
 	if [[ ! -x $BUILDER ]]; then
 		# echo "[WARNING] podman is not installed, trying with docker"
@@ -50,7 +50,7 @@ if [[ ${pullAssets} -eq 1 ]]; then
 	${BUILDER} rmi ${imageName}:bootstrap
 fi
 
-if [[ $(git diff-index HEAD --) ]] || [[ ${pullAssets} -eq 1 ]]; then
+if [[ $(git diff-index HEAD --) ]] || [[ ${PULL_ASSETS} -eq 1 ]]; then
 	git add sources Dockerfile .gitignore || true
 	log "[INFO] Upload new sources: ${resticRestServerAssets}"
 	rhpkg new-sources ${resticRestServerAssets}

--- a/codeready-workspaces-backup/get-sources.sh
+++ b/codeready-workspaces-backup/get-sources.sh
@@ -15,9 +15,12 @@ resticRestServerAssets=assets-rest-server.tgz
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
 		'-p'|'--pull-assets') pullAssets=1; shift 0;;
+		'-a'|'--publish-assets') exit 0; shift 0;;
+		'-d'|'--delete-assets') exit 0; shift 0;;
 		'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
 		'-f'|'--force-build') forceBuild=1; shift 0;;
 		'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
+		'-v') CSV_VERSION="$2"; shift 1;;
 	esac
 	shift 1
 done

--- a/codeready-workspaces-configbump/build/rhel.binary.build.sh
+++ b/codeready-workspaces-configbump/build/rhel.binary.build.sh
@@ -23,7 +23,7 @@ if [[ ${MIDSTM_BRANCH} != "crw-"*"-rhel-"* ]]; then MIDSTM_BRANCH="crw-2-rhel-8"
 
 usage () {
     echo "
-Usage:   $0 -v [CRW CSV_VERSION] [--noupload] [-b MIDSTM_BRANCH] [-ght GITHUB_TOKEN] -n [GITHUB_RELEASE_NAME]
+Usage:   $0 -v [CRW CSV_VERSION] [--noupload] [-ght GITHUB_TOKEN] -n [ASSET_NAME]
 Example: $0 -v 2.y.0 --noupload -n configbump
 "
     exit

--- a/codeready-workspaces-configbump/build/rhel.binary.build.sh
+++ b/codeready-workspaces-configbump/build/rhel.binary.build.sh
@@ -16,7 +16,6 @@ set -e
 
 # defaults
 CSV_VERSION=2.y.0 # csv 2.y.0
-SYNC_REPO="configbump"
 UPLOAD_TO_GH=1
 
 MIDSTM_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "crw-2-rhel-8")
@@ -24,8 +23,8 @@ if [[ ${MIDSTM_BRANCH} != "crw-"*"-rhel-"* ]]; then MIDSTM_BRANCH="crw-2-rhel-8"
 
 usage () {
     echo "
-Usage:   $0 -v [CRW CSV_VERSION] [--noupload] [-b MIDSTM_BRANCH] [-ght GITHUB_TOKEN]
-Example: $0 -v 2.y.0 --noupload
+Usage:   $0 -v [CRW CSV_VERSION] [--noupload] [-b MIDSTM_BRANCH] [-ght GITHUB_TOKEN] -n [GITHUB_RELEASE_NAME]
+Example: $0 -v 2.y.0 --noupload -n configbump
 "
     exit
 }
@@ -35,22 +34,20 @@ if [[ $# -lt 1 ]]; then usage; fi
 while [[ "$#" -gt 0 ]]; do
   case $1 in
     '-v') CSV_VERSION="$2"; shift 1;;
-    '-b') MIDSTM_BRANCH="$2"; shift 1;;
     '-ght') GITHUB_TOKEN="$2"; export GITHUB_TOKEN="${GITHUB_TOKEN}"; shift 1;;
-    '-n'|'--noupload') UPLOAD_TO_GH=0;;
+    '-n') ASSET_NAME="$2"; shift 1;;
+    '--noupload') UPLOAD_TO_GH=0;;
     '--help'|'-h') usage;;
   esac
   shift 1
 done
 
 ARCH="$(uname -m)"
-
-#call rhel.Dockerfile.extract.asets
 chmod +x ./build/dockerfiles/*.sh
 ./build/dockerfiles/rhel.Dockerfile.extract.assets.sh
 
 if [[ ! ${WORKSPACE} ]]; then WORKSPACE=/tmp; fi
-tarball="${WORKSPACE}/asset-${SYNC_REPO}-${ARCH}.tar.gz"
+tarball="${WORKSPACE}/asset-${ASSET_NAME}-${ARCH}.tar.gz"
 if [[ ${UPLOAD_TO_GH} -eq 1 ]]; then
   # upload the binary to GH
   if [[ ! -x ./uploadAssetsToGHRelease.sh ]]; then 
@@ -59,5 +56,5 @@ if [[ ${UPLOAD_TO_GH} -eq 1 ]]; then
   # delete existing release & tag & assets -- this will remove everything for each push for each arch, so can't be done here
   # ./uploadAssetsToGHRelease.sh --delete-assets -v "${CSV_VERSION}" -b "${MIDSTM_BRANCH}" --asset-name "${SYNC_REPO}"
   # create a new release & tag w/ fresh assets
-  ./uploadAssetsToGHRelease.sh --publish-assets -v "${CSV_VERSION}" -b "${MIDSTM_BRANCH}" --asset-name "${SYNC_REPO}" "${tarball}"
+  ./uploadAssetsToGHRelease.sh --publish-assets -v "${CSV_VERSION}" -b "${MIDSTM_BRANCH}" --asset-name "${ASSET_NAME}" "${tarball}"
 fi

--- a/codeready-workspaces-configbump/get-sources.sh
+++ b/codeready-workspaces-configbump/get-sources.sh
@@ -80,32 +80,32 @@ if [[ ${PULL_ASSETS} -eq 1 ]]; then
 		log "[INFO] Push change:"
 		git pull; git push; git status -s || true
 	fi
-fi
 
-if [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
-	echo "[INFO] #1 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
-	git status || true
-	tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
-	taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
-	ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
-	if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
-
-$ERRORS
-
-"; exit 1; fi
-fi
-
-if [[ ${forceBuild} -eq 1 ]]; then
-	echo "[INFO] #2 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
-	git status || true
-	tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
-	taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
-	ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
-	if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
+	if [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
+		echo "[INFO] #1 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
+		git status || true
+		tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
+		taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
+		ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
+		if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
 
 $ERRORS
 
 "; exit 1; fi
+	fi
 else
-	log "[INFO] No new sources, so nothing to build."
+	if [[ ${forceBuild} -eq 1 ]]; then
+		echo "[INFO] #2 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
+		git status || true
+		tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
+		taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
+		ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
+		if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
+
+$ERRORS
+
+	"; exit 1; fi
+	else
+		log "[INFO] No new sources, so nothing to build."
+	fi
 fi

--- a/codeready-workspaces-configbump/get-sources.sh
+++ b/codeready-workspaces-configbump/get-sources.sh
@@ -5,7 +5,7 @@ verbose=1
 scratchFlag=""
 doRhpkgContainerBuild=1
 forceBuild=0
-# NOTE: pullAssets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
+# NOTE: --pull-assets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
 # here we want to collect assets during sync-to-downsteam (using get-sources.sh -n -p)
 # so that rhpkg build is simply a brew wrapper (using get-sources.sh -f)
 PULL_ASSETS=0
@@ -63,22 +63,25 @@ if [[ ${PUBLISH_ASSETS} -eq 1 ]]; then
 	exit 0;
 fi
 
-log "[INFO] Download Assets:"
-./uploadAssetsToGHRelease.sh --fetch-assets -v "${CSV_VERSION}" -n ${ASSET_NAME}
+if [[ ${PULL_ASSETS} -eq 1 ]]; then
+	log "[INFO] Download Assets:"
+	./uploadAssetsToGHRelease.sh --fetch-assets -v "${CSV_VERSION}" -n ${ASSET_NAME}
 
-#get names of the downloaded tarballs
-theTarGzs="$(ls *.tar.gz)"
+	#get names of the downloaded tarballs
+	theTarGzs="$(ls *.tar.gz)"
 
-log "[INFO] Upload new sources: ${theTarGzs}"
-rhpkg new-sources ${theTarGzs}
-log "[INFO] Commit new sources from:${theTarGzs}"
-COMMIT_MSG="GH releases :: ${theTarGzs}"
-if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]]; then 
-	log "[INFO] No new sources, so nothing to build."
-elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
-	log "[INFO] Push change:"
-	git pull; git push; git status -s || true
+	log "[INFO] Upload new sources: ${theTarGzs}"
+	rhpkg new-sources ${theTarGzs}
+	log "[INFO] Commit new sources from:${theTarGzs}"
+	COMMIT_MSG="GH releases :: ${theTarGzs}"
+	if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]]; then 
+		log "[INFO] No new sources, so nothing to build."
+	elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
+		log "[INFO] Push change:"
+		git pull; git push; git status -s || true
+	fi
 fi
+
 if [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
 	echo "[INFO] #1 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
 	git status || true

--- a/codeready-workspaces-configbump/get-sources.sh
+++ b/codeready-workspaces-configbump/get-sources.sh
@@ -73,7 +73,7 @@ if [[ ${PULL_ASSETS} -eq 1 ]]; then
 	log "[INFO] Upload new sources: ${theTarGzs}"
 	rhpkg new-sources ${theTarGzs}
 	log "[INFO] Commit new sources from:${theTarGzs}"
-	COMMIT_MSG="GH releases :: ${theTarGzs}"
+	COMMIT_MSG="chore: update from GH ${ASSET_NAME} assets :: ${theTarGzs}"
 	if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]]; then 
 		log "[INFO] No new sources, so nothing to build."
 	elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then

--- a/codeready-workspaces-configbump/get-sources.sh
+++ b/codeready-workspaces-configbump/get-sources.sh
@@ -8,7 +8,10 @@ forceBuild=0
 # NOTE: pullAssets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
 # here we want to collect assets during sync-to-downsteam (using get-sources.sh -n -p)
 # so that rhpkg build is simply a brew wrapper (using get-sources.sh -f)
-pullAssets=0
+PULL_ASSETS=0
+PUBLISH_ASSETS=0
+DELETE_ASSETS=0
+ASSET_NAME="configbump"
 
 # compute project name from current dir
 SCRIPT_DIR=$(cd "$(dirname "$0")" || exit; pwd); 
@@ -25,12 +28,13 @@ CSV_VERSION=$(curl -sSLo- "https://raw.githubusercontent.com/redhat-developer/co
 
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
-		'-p'|'--pull-assets') pullAssets=1; shift 0;;
+		'-d'|'--delete-assets') DELETE_ASSETS=1; shift 0;;
+		'-a'|'--publish-assets') PUBLISH_ASSETS=1; shift 0;;
+		'-p'|'--pull-assets') PULL_ASSETS=1; shift 0;;
 		'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
 		'-f'|'--force-build') forceBuild=1; shift 0;;
 		'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
 		'-v') CSV_VERSION="$2"; shift 1;;
-		'-b') MIDSTM_BRANCH="$2"; shift 1;;
 		'-ght') GITHUB_TOKEN="$2"; shift 1;;
 	esac
 	shift 1
@@ -42,77 +46,63 @@ function log()
 	echo "$1"
 	fi
 }
-function logn()
-{
-	if [[ ${verbose} -gt 0 ]]; then
-	echo -n "$1"
-	fi
-}
 
-curlWithToken()
-{
-  curl -sSL -H "Authorization:token ${GITHUB_TOKEN}" "$1" "$2" "$3"
-}
-
-# check if existing release exists
-releases_URL="https://api.github.com/repos/redhat-developer/codeready-workspaces-images/releases"
-# shellcheck disable=2086
-RELEASE_ID=$(curlWithToken -H "Accept: application/vnd.github.v3+json" $releases_URL | jq -r --arg CSV_VERSION "${CSV_VERSION}" --arg projectName "${projectName}" '.[] | select(.name=="Assets for the '$CSV_VERSION' '$projectName' release")|.url' || true); RELEASE_ID=${RELEASE_ID##*/}
-if [[ -z $RELEASE_ID ]]; then 
-	echo "ERROR: could not compute RELEASE_ID from which to collect assets! Check https://api.github.com/repos/redhat-developer/codeready-workspaces-images/releases"
-	exit 1
+if [[ ! -x ./uploadAssetsToGHRelease.sh ]]; then 
+    curl -sSLO "https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/${MIDSTM_BRANCH}/product/uploadAssetsToGHRelease.sh" && chmod +x uploadAssetsToGHRelease.sh
 fi
 
-# get the public URLs for the tarball(s) from browser_download_url
-theTarGzs="$(curlWithToken https://api.github.com/repos/redhat-developer/codeready-workspaces-images/releases/${RELEASE_ID} | jq -r '.assets[].browser_download_url')"
+if [[ ${DELETE_ASSETS} -eq 1 ]]; then
+	log "[INFO] Delete Previous GitHub Releases:"
+	./uploadAssetsToGHRelease.sh --delete-assets -v "${CSV_VERSION}" -n ${ASSET_NAME}
+	exit 0;
+fi
 
-#### override any existing tarballs with newer ones from Jenkins build
-for theTarGz in ${theTarGzs}; do
-	log "[INFO] Download ${theTarGz} -> ${theTarGz##*/}"
-	# TODO can we check if we already have the identical file before re-downloading it? eg., store sha512sums as assets files?
-	if [[ ! -f ./${theTarGz##*/} ]] || [[ ${pullAssets} -eq 1 ]]; then 
-		if [[ -f ./${theTarGz##*/} ]]; then rm -f ./${theTarGz##*/}; fi
-		curl -sSLo ./${theTarGz##*/} ${theTarGz}
-		outputFiles="${outputFiles} ${theTarGz##*/}"
-	fi
-done
+if [[ ${PUBLISH_ASSETS} -eq 1 ]]; then
+	log "[INFO] Build Assets and Publish to GitHub Releases:"
+	./build/rhel.binary.build.sh -v ${CSV_VERSION} -n ${ASSET_NAME}
+	exit 0;
+fi
 
-if [[ ${outputFiles} ]]; then
-	log "[INFO] Upload new sources: ${outputFiles}"
-	rhpkg new-sources ${outputFiles}
-	log "[INFO] Commit new sources from:${outputFiles}"
-	COMMIT_MSG="GH releases :: ${outputFiles}"
-	if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]]; then 
-		log "[INFO] No new sources, so nothing to build."
-	elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
-		log "[INFO] Push change:"
-		git pull; git push; git status -s || true
-	fi
-	if [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
-		echo "[INFO] #1 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
-		git status || true
-		tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
-		taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
-		ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
-		if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
+log "[INFO] Download Assets:"
+./uploadAssetsToGHRelease.sh --fetch-assets -v "${CSV_VERSION}" -n ${ASSET_NAME}
+
+#get names of the downloaded tarballs
+theTarGzs="$(ls *.tar.gz)"
+
+log "[INFO] Upload new sources: ${theTarGzs}"
+rhpkg new-sources ${theTarGzs}
+log "[INFO] Commit new sources from:${theTarGzs}"
+COMMIT_MSG="GH releases :: ${theTarGzs}"
+if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]]; then 
+	log "[INFO] No new sources, so nothing to build."
+elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
+	log "[INFO] Push change:"
+	git pull; git push; git status -s || true
+fi
+if [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
+	echo "[INFO] #1 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
+	git status || true
+	tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
+	taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
+	ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
+	if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
 
 $ERRORS
 
 "; exit 1; fi
-	fi
+fi
+
+if [[ ${forceBuild} -eq 1 ]]; then
+	echo "[INFO] #2 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
+	git status || true
+	tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
+	taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
+	ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
+	if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
+
+$ERRORS
+
+"; exit 1; fi
 else
-	if [[ ${forceBuild} -eq 1 ]]; then
-		echo "[INFO] #2 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
-		git status || true
-		tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
-		taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
-		ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
-		if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
-
-$ERRORS
-
-"; exit 1; fi
-	else
-		log "[INFO] No new sources, so nothing to build."
-	fi
+	log "[INFO] No new sources, so nothing to build."
 fi

--- a/codeready-workspaces-dashboard/get-sources.sh
+++ b/codeready-workspaces-dashboard/get-sources.sh
@@ -13,9 +13,12 @@ pullAssets=0
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
 		'-p'|'--pull-assets') pullAssets=1; shift 0;;
+		'-a'|'--publish-assets') exit 0; shift 0;;
+		'-d'|'--delete-assets') exit 0; shift 0;;
 		'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
 		'-f'|'--force-build') forceBuild=1; shift 0;;
 		'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
+		'-v') CSV_VERSION="$2"; shift 1;;
 	esac
 	shift 1
 done

--- a/codeready-workspaces-dashboard/get-sources.sh
+++ b/codeready-workspaces-dashboard/get-sources.sh
@@ -5,14 +5,14 @@ verbose=1
 scratchFlag=""
 doRhpkgContainerBuild=1
 forceBuild=0
-# NOTE: pullAssets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
+# NOTE: --pull-assets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
 # here we want to collect assets during sync-to-downsteam (using get-sources.sh -n -p)
 # so that rhpkg build is simply a brew wrapper (using get-sources.sh -f)
-pullAssets=0
+PULL_ASSETS=0
 
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
-		'-p'|'--pull-assets') pullAssets=1; shift 0;;
+		'-p'|'--pull-assets') PULL_ASSETS=1; shift 0;;
 		'-a'|'--publish-assets') exit 0; shift 0;;
 		'-d'|'--delete-assets') exit 0; shift 0;;
 		'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
@@ -29,14 +29,8 @@ function log()
 	echo "$1"
 	fi
 }
-function logn()
-{
-	if [[ ${verbose} -gt 0 ]]; then
-	echo -n "$1"
-	fi
-}
 
-if [[ ${pullAssets} -eq 1 ]]; then 
+if [[ ${PULL_ASSETS} -eq 1 ]]; then 
 	# step one - build the builder image
 	BUILDER=$(command -v podman || true)
 	if [[ ! -x $BUILDER ]]; then
@@ -58,7 +52,7 @@ if [[ ${pullAssets} -eq 1 ]]; then
     outputFiles=asset-node-modules-cache.tgz
 fi
 
-if [[ $(git diff-index HEAD --) ]] || [[ ${pullAssets} -eq 1 ]]; then
+if [[ $(git diff-index HEAD --) ]] || [[ ${PULL_ASSETS} -eq 1 ]]; then
 	git add sources Dockerfile .gitignore || true
 	log "[INFO] Upload new sources: ${outputFiles}"
 	rhpkg new-sources ${outputFiles}

--- a/codeready-workspaces-devfileregistry/get-sources.sh
+++ b/codeready-workspaces-devfileregistry/get-sources.sh
@@ -4,10 +4,10 @@ verbose=0
 scratchFlag=""
 doRhpkgContainerBuild=1
 forceBuild=0
-# NOTE: pullAssets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
+# NOTE: --pull-assets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
 # here we want to collect assets during sync-to-downsteam (using get-sources.sh -n -p)
 # so that rhpkg build is simply a brew wrapper (using get-sources.sh -f)
-pullAssets=0
+PULL_ASSETS=0
 
 tmpContainer=devfileregistry:tmp
 filesToInclude='./devfiles ./resources'
@@ -15,7 +15,7 @@ filesToExclude=() # nothing to exclude; if there was, use (-x rsync-pattern-to--
 
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
-		'-p'|'--pull-assets') pullAssets=1; shift 0;;
+		'-p'|'--pull-assets') PULL_ASSETS=1; shift 0;;
 		'-a'|'--publish-assets') exit 0; shift 0;;
 		'-d'|'--delete-assets') exit 0; shift 0;;
 		'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
@@ -33,7 +33,7 @@ function log()
 	fi
 }
 
-if [[ ${pullAssets} -eq 1 ]]; then 
+if [[ ${PULL_ASSETS} -eq 1 ]]; then 
 	BUILDER=$(command -v podman || true)
 	if [[ ! -x $BUILDER ]]; then
 		# echo "[WARNING] podman is not installed, trying with docker"
@@ -123,7 +123,7 @@ if [[ ${pullAssets} -eq 1 ]]; then
 fi
 
 # update tarballs - step 4 - commit changes if diff different
-if [[ ${TAR_DIFF} ]] || [[ ${TAR_DIFF2} ]] || [[ ${pullAssets} -eq 1 ]]; then
+if [[ ${TAR_DIFF} ]] || [[ ${TAR_DIFF2} ]] || [[ ${PULL_ASSETS} -eq 1 ]]; then
 	log "[INFO] Commit new sources"
 	rhpkg new-sources ${TARGZs}
 	COMMIT_MSG="Update ${TARGZs}"

--- a/codeready-workspaces-devfileregistry/get-sources.sh
+++ b/codeready-workspaces-devfileregistry/get-sources.sh
@@ -16,9 +16,12 @@ filesToExclude=() # nothing to exclude; if there was, use (-x rsync-pattern-to--
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
 		'-p'|'--pull-assets') pullAssets=1; shift 0;;
+		'-a'|'--publish-assets') exit 0; shift 0;;
+		'-d'|'--delete-assets') exit 0; shift 0;;
 		'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
 		'-f'|'--force-build') forceBuild=1; shift 0;;
 		'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
+		'-v') CSV_VERSION="$2"; shift 1;;
 	esac
 	shift 1
 done

--- a/codeready-workspaces-idea/get-sources.sh
+++ b/codeready-workspaces-idea/get-sources.sh
@@ -5,16 +5,16 @@ verbose=1
 scratchFlag=""
 doRhpkgContainerBuild=1
 forceBuild=0
-# NOTE: pullAssets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
+# NOTE: --pull-assets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
 # here we want to collect assets during sync-to-downsteam (using get-sources.sh -n -p)
 # so that rhpkg build is simply a brew wrapper (using get-sources.sh -f)
-pullAssets=0
+PULL_ASSETS=0
 
 idePackagingUrl=https://download-cdn.jetbrains.com/idea/ideaIC-2020.3.3.tar.gz
 
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
-		'-p'|'--pull-assets') pullAssets=1; shift 0;;
+		'-p'|'--pull-assets') PULL_ASSETS=1; shift 0;;
 		'-a'|'--publish-assets') exit 0; shift 0;;
 		'-d'|'--delete-assets') exit 0; shift 0;;
 		'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
@@ -31,14 +31,8 @@ function log()
 	echo "$1"
 	fi
 }
-function logn()
-{
-	if [[ ${verbose} -gt 0 ]]; then
-	echo -n "$1"
-	fi
-}
 
-if [[ ${pullAssets} -eq 1 ]]; then
+if [[ ${PULL_ASSETS} -eq 1 ]]; then
   JDK_VER="11"
   sudo yum -y install java-${JDK_VER}-openjdk java-${JDK_VER}-openjdk-devel
   export PATH="/usr/lib/jvm/java-${JDK_VER}-openjdk:/usr/bin:${PATH}"
@@ -67,7 +61,7 @@ if [[ ${pullAssets} -eq 1 ]]; then
   outputFiles="asset-ide-packaging.tar.gz asset-projector-server-assembly.zip asset-static-assembly.tar.gz"
 fi
 
-if [[ $(git diff-index HEAD --) ]] || [[ ${pullAssets} -eq 1 ]]; then
+if [[ $(git diff-index HEAD --) ]] || [[ ${PULL_ASSETS} -eq 1 ]]; then
 	git add sources Dockerfile .gitignore || true
 	log "[INFO] Upload new sources: ${outputFiles}"
 	# shellcheck disable=SC2086

--- a/codeready-workspaces-idea/get-sources.sh
+++ b/codeready-workspaces-idea/get-sources.sh
@@ -15,9 +15,12 @@ idePackagingUrl=https://download-cdn.jetbrains.com/idea/ideaIC-2020.3.3.tar.gz
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
 		'-p'|'--pull-assets') pullAssets=1; shift 0;;
+		'-a'|'--publish-assets') exit 0; shift 0;;
+		'-d'|'--delete-assets') exit 0; shift 0;;
 		'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
 		'-f'|'--force-build') forceBuild=1; shift 0;;
 		'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
+		'-v') CSV_VERSION="$2"; shift 1;;
 	esac
 	shift 1
 done

--- a/codeready-workspaces-imagepuller/get-sources.sh
+++ b/codeready-workspaces-imagepuller/get-sources.sh
@@ -13,9 +13,12 @@ pullAssets=0
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
 		'-p'|'--pull-assets') pullAssets=1; shift 0;;
+		'-a'|'--publish-assets') exit 0; shift 0;;
+		'-d'|'--delete-assets') exit 0; shift 0;;
 		'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
 		'-f'|'--force-build') forceBuild=1; shift 0;;
 		'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
+		'-v') CSV_VERSION="$2"; shift 1;;
 	esac
 	shift 1
 done

--- a/codeready-workspaces-imagepuller/get-sources.sh
+++ b/codeready-workspaces-imagepuller/get-sources.sh
@@ -5,14 +5,14 @@ doRhpkgContainerBuild=1
 forceBuild=0
 tmpContainer=imagepuller:tmp
 verbose=0
-# NOTE: pullAssets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
+# NOTE: --pull-assets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
 # here we want to collect assets during sync-to-downsteam (using get-sources.sh -n -p)
 # so that rhpkg build is simply a brew wrapper (using get-sources.sh -f)
-pullAssets=0
+PULL_ASSETS=0
 
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
-		'-p'|'--pull-assets') pullAssets=1; shift 0;;
+		'-p'|'--pull-assets') PULL_ASSETS=1; shift 0;;
 		'-a'|'--publish-assets') exit 0; shift 0;;
 		'-d'|'--delete-assets') exit 0; shift 0;;
 		'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
@@ -30,7 +30,7 @@ function log()
 	fi
 }
 
-if [[ ${pullAssets} -eq 1 ]]; then 
+if [[ ${PULL_ASSETS} -eq 1 ]]; then 
 	BUILDER=$(command -v podman || true)
 	if [[ ! -x $BUILDER ]]; then
 		# echo "[WARNING] podman is not installed, trying with docker"
@@ -89,7 +89,7 @@ if [[ ${pullAssets} -eq 1 ]]; then
 	${BUILDER} rmi ${tmpContainer}
 fi
 # update tarballs - step 4 - commit changes if diff different
-if [[ ${TAR_DIFF} ]] || [[ ${pullAssets} -eq 1 ]]; then
+if [[ ${TAR_DIFF} ]] || [[ ${PULL_ASSETS} -eq 1 ]]; then
 	log "[INFO] Commit new sources"
 	rhpkg new-sources ${TARGZs}
 	COMMIT_MSG="Update ${TARGZs}"

--- a/codeready-workspaces-jwtproxy/get-sources.sh
+++ b/codeready-workspaces-jwtproxy/get-sources.sh
@@ -5,14 +5,14 @@ verbose=1
 scratchFlag=""
 doRhpkgContainerBuild=1
 forceBuild=0
-# NOTE: pullAssets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
+# NOTE: --pull-assets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
 # here we want to collect assets during sync-to-downsteam (using get-sources.sh -n -p)
 # so that rhpkg build is simply a brew wrapper (using get-sources.sh -f)
-pullAssets=0
+PULL_ASSETS=0
 
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
-		'-p'|'--pull-assets') pullAssets=1; shift 0;;
+		'-p'|'--pull-assets') PULL_ASSETS=1; shift 0;;
 		'-a'|'--publish-assets') exit 0; shift 0;;
 		'-d'|'--delete-assets') exit 0; shift 0;;
 		'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
@@ -29,14 +29,8 @@ function log()
 	echo "$1"
 	fi
 }
-function logn()
-{
-	if [[ ${verbose} -gt 0 ]]; then
-	echo -n "$1"
-	fi
-}
 
-if [[ ${pullAssets} -eq 1 ]]; then 
+if [[ ${PULL_ASSETS} -eq 1 ]]; then 
 	# step one - build the builder image
 	BUILDER=$(command -v podman || true)
 	if [[ ! -x $BUILDER ]]; then
@@ -71,7 +65,7 @@ if [[ ${pullAssets} -eq 1 ]]; then
 	rm -f "asset-vendor-$(uname -m).tgz"
 fi
 
-if [[ $(git diff-index HEAD --) ]] || [[ ${pullAssets} -eq 1 ]]; then
+if [[ $(git diff-index HEAD --) ]] || [[ ${PULL_ASSETS} -eq 1 ]]; then
 	git add vendor bootstrap.Dockerfile || true
 	log "[INFO] Commit new vendor folder"
 	COMMIT_MSG="vendor folder"

--- a/codeready-workspaces-jwtproxy/get-sources.sh
+++ b/codeready-workspaces-jwtproxy/get-sources.sh
@@ -13,9 +13,12 @@ pullAssets=0
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
 		'-p'|'--pull-assets') pullAssets=1; shift 0;;
+		'-a'|'--publish-assets') exit 0; shift 0;;
+		'-d'|'--delete-assets') exit 0; shift 0;;
 		'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
 		'-f'|'--force-build') forceBuild=1; shift 0;;
 		'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
+		'-v') CSV_VERSION="$2"; shift 1;;
 	esac
 	shift 1
 done

--- a/codeready-workspaces-machineexec/get-sources.sh
+++ b/codeready-workspaces-machineexec/get-sources.sh
@@ -12,9 +12,12 @@ pullAssets=0
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
 		'-p'|'--pull-assets') pullAssets=1; shift 0;;
+		'-a'|'--publish-assets') exit 0; shift 0;;
+		'-d'|'--delete-assets') exit 0; shift 0;;
 		'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
 		'-f'|'--force-build') forceBuild=1; shift 0;;
 		'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
+		'-v') CSV_VERSION="$2"; shift 1;;
 	esac
 	shift 1
 done

--- a/codeready-workspaces-machineexec/get-sources.sh
+++ b/codeready-workspaces-machineexec/get-sources.sh
@@ -4,14 +4,14 @@
 scratchFlag=""
 doRhpkgContainerBuild=1
 forceBuild=0
-# NOTE: pullAssets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
+# NOTE: --pull-assets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
 # here we want to collect assets during sync-to-downsteam (using get-sources.sh -n -p)
 # so that rhpkg build is simply a brew wrapper (using get-sources.sh -f)
-pullAssets=0
+PULL_ASSETS=0
 
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
-		'-p'|'--pull-assets') pullAssets=1; shift 0;;
+		'-p'|'--pull-assets') PULL_ASSETS=1; shift 0;;
 		'-a'|'--publish-assets') exit 0; shift 0;;
 		'-d'|'--delete-assets') exit 0; shift 0;;
 		'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;

--- a/codeready-workspaces-operator-bundle/get-sources.sh
+++ b/codeready-workspaces-operator-bundle/get-sources.sh
@@ -12,9 +12,12 @@ pullAssets=0
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
 		'-p'|'--pull-assets') pullAssets=1; shift 0;;
+		'-a'|'--publish-assets') exit 0; shift 0;;
+		'-d'|'--delete-assets') exit 0; shift 0;;
 		'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
 		'-f'|'--force-build') forceBuild=1; shift 0;;
 		'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
+		'-v') CSV_VERSION="$2"; shift 1;;
 	esac
 	shift 1
 done

--- a/codeready-workspaces-operator-bundle/get-sources.sh
+++ b/codeready-workspaces-operator-bundle/get-sources.sh
@@ -4,14 +4,14 @@
 scratchFlag=""
 doRhpkgContainerBuild=1
 forceBuild=0
-# NOTE: pullAssets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
+# NOTE: --pull-assets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
 # here we want to collect assets during sync-to-downsteam (using get-sources.sh -n -p)
 # so that rhpkg build is simply a brew wrapper (using get-sources.sh -f)
-pullAssets=0
+PULL_ASSETS=0
 
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
-		'-p'|'--pull-assets') pullAssets=1; shift 0;;
+		'-p'|'--pull-assets') PULL_ASSETS=1; shift 0;;
 		'-a'|'--publish-assets') exit 0; shift 0;;
 		'-d'|'--delete-assets') exit 0; shift 0;;
 		'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;

--- a/codeready-workspaces-operator-metadata/get-sources.sh
+++ b/codeready-workspaces-operator-metadata/get-sources.sh
@@ -12,9 +12,12 @@ pullAssets=0
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
 		'-p'|'--pull-assets') pullAssets=1; shift 0;;
+		'-a'|'--publish-assets') exit 0; shift 0;;
+		'-d'|'--delete-assets') exit 0; shift 0;;
 		'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
 		'-f'|'--force-build') forceBuild=1; shift 0;;
 		'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
+		'-v') CSV_VERSION="$2"; shift 1;;
 	esac
 	shift 1
 done

--- a/codeready-workspaces-operator-metadata/get-sources.sh
+++ b/codeready-workspaces-operator-metadata/get-sources.sh
@@ -4,14 +4,14 @@
 scratchFlag=""
 doRhpkgContainerBuild=1
 forceBuild=0
-# NOTE: pullAssets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
+# NOTE: --pull-assets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
 # here we want to collect assets during sync-to-downsteam (using get-sources.sh -n -p)
 # so that rhpkg build is simply a brew wrapper (using get-sources.sh -f)
-pullAssets=0
+PULL_ASSETS=0
 
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
-		'-p'|'--pull-assets') pullAssets=1; shift 0;;
+		'-p'|'--pull-assets') PULL_ASSETS=1; shift 0;;
 		'-a'|'--publish-assets') exit 0; shift 0;;
 		'-d'|'--delete-assets') exit 0; shift 0;;
 		'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;

--- a/codeready-workspaces-operator/get-sources.sh
+++ b/codeready-workspaces-operator/get-sources.sh
@@ -5,10 +5,10 @@ verbose=1
 scratchFlag=""
 doRhpkgContainerBuild=1
 forceBuild=0
-# NOTE: pullAssets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
+# NOTE: --pull-assets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
 # here we want to collect assets during sync-to-downsteam (using get-sources.sh -n -p)
 # so that rhpkg build is simply a brew wrapper (using get-sources.sh -f)
-pullAssets=0
+PULL_ASSETS=0
 
 SCRIPT_DIR=$(dirname $(readlink -f "${BASH_SOURCE[0]}"))
 
@@ -18,7 +18,7 @@ RESTIC_VERSION=$(sed -n 's|.*RESTIC_TAG=\(.*\)|\1|p' Dockerfile)
 
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
-		'-p'|'--pull-assets') pullAssets=1; shift 0;;
+		'-p'|'--pull-assets') PULL_ASSETS=1; shift 0;;
 		'-a'|'--publish-assets') exit 0; shift 0;;
 		'-d'|'--delete-assets') exit 0; shift 0;;
 		'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
@@ -44,7 +44,7 @@ function logn()
 	fi
 }
 
-if [[ ${pullAssets} -eq 1 ]]; then 
+if [[ ${PULL_ASSETS} -eq 1 ]]; then 
 	if [[ -x "${SCRIPT_DIR}"/build/scripts/util.sh ]]; then  source "${SCRIPT_DIR}"/build/scripts/util.sh;
 	else echo "Error: can't find build/scripts/util.sh in ${SCRIPT_DIR}"; exit 1; fi
 	updateDockerfileArgs Dockerfile Dockerfile.2
@@ -87,7 +87,7 @@ else
 fi
 
 if [[ $(git diff-index HEAD --) ]] || [[ $(diff -U 0 --suppress-common-lines -b Dockerfile.2 Dockerfile) ]] || \
-	[[ ${pullAssets} -eq 1 ]]; then
+	[[ ${PULL_ASSETS} -eq 1 ]]; then
 	mv -f Dockerfile.2 Dockerfile
 
 	git add bootstrap.Dockerfile || true

--- a/codeready-workspaces-operator/get-sources.sh
+++ b/codeready-workspaces-operator/get-sources.sh
@@ -19,11 +19,14 @@ RESTIC_VERSION=$(sed -n 's|.*RESTIC_TAG=\(.*\)|\1|p' Dockerfile)
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
 		'-p'|'--pull-assets') pullAssets=1; shift 0;;
+		'-a'|'--publish-assets') exit 0; shift 0;;
+		'-d'|'--delete-assets') exit 0; shift 0;;
 		'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
 		'-f'|'--force-build') forceBuild=1; shift 0;;
 		'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
 		'--dwob'|'--dwcv') DEV_WORKSPACE_CONTROLLER_VERSION="$2"; shift 1;;
 		'--hrtpb'|'--hrtpv') DEV_HEADER_REWRITE_TRAEFIK_PLUGIN="$2"; shift 1;;
+		'-v') CSV_VERSION="$2"; shift 1;;
 	esac
 	shift 1
 done

--- a/codeready-workspaces-plugin-java11-openj9/get-sources.sh
+++ b/codeready-workspaces-plugin-java11-openj9/get-sources.sh
@@ -12,8 +12,11 @@ while [[ "$#" -gt 0 ]]; do
 	'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
 	'-f'|'--force-build') forceBuild=1; shift 0;;
 	'-p'|'--pull-assets') pullAssets=1; shift 0;;
+	'-a'|'--publish-assets') exit 0; shift 0;;
+	'-d'|'--delete-assets') exit 0; shift 0;;
 	'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
 	'-t'|'--target') targetFlag="--target $2"; shift 1;;
+	'-v') CSV_VERSION="$2"; shift 1;;
 	*) JOB_BRANCH="$1"; shift 0;;
 	esac
 	shift 1

--- a/codeready-workspaces-plugin-java11-openj9/get-sources.sh
+++ b/codeready-workspaces-plugin-java11-openj9/get-sources.sh
@@ -5,13 +5,13 @@ scratchFlag=""
 JOB_BRANCH=""
 doRhpkgContainerBuild=1
 forceBuild=0
-pullAssets=0
+PULL_ASSETS=0
 targetFlag=""
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
 	'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
 	'-f'|'--force-build') forceBuild=1; shift 0;;
-	'-p'|'--pull-assets') pullAssets=1; shift 0;;
+	'-p'|'--pull-assets') PULL_ASSETS=1; shift 0;;
 	'-a'|'--publish-assets') exit 0; shift 0;;
 	'-d'|'--delete-assets') exit 0; shift 0;;
 	'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
@@ -26,12 +26,6 @@ function log()
 {
 	if [[ ${verbose} -gt 0 ]]; then
 	echo "$1"
-	fi
-}
-function logn()
-{
-	if [[ ${verbose} -gt 0 ]]; then
-	echo -n "$1"
 	fi
 }
 
@@ -60,7 +54,7 @@ sed Dockerfile \
 	> Dockerfile.2
 
 # pull maven (if not present, or forced, or new version in dockerfile)
-if [[ ! -f apache-maven-${MAVEN_VERSION}-bin.tar.gz ]] || [[ $(diff -U 0 --suppress-common-lines -b Dockerfile.2 Dockerfile) ]] || [[ ${pullAssets} -eq 1 ]]; then
+if [[ ! -f apache-maven-${MAVEN_VERSION}-bin.tar.gz ]] || [[ $(diff -U 0 --suppress-common-lines -b Dockerfile.2 Dockerfile) ]] || [[ ${PULL_ASSETS} -eq 1 ]]; then
 	mv -f Dockerfile.2 Dockerfile
 	curl -sSL -O https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip
 	curl -sSL -O http://mirror.csclub.uwaterloo.ca/apache/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz

--- a/codeready-workspaces-plugin-java11/get-sources.sh
+++ b/codeready-workspaces-plugin-java11/get-sources.sh
@@ -5,12 +5,12 @@ scratchFlag=""
 JOB_BRANCH=""
 doRhpkgContainerBuild=1
 forceBuild=0
-pullAssets=0
+PULL_ASSETS=0
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
 	'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
 	'-f'|'--force-build') forceBuild=1; shift 0;;
-	'-p'|'--pull-assets') pullAssets=1; shift 0;;
+	'-p'|'--pull-assets') PULL_ASSETS=1; shift 0;;
 	'-a'|'--publish-assets') exit 0; shift 0;;
 	'-d'|'--delete-assets') exit 0; shift 0;;
 	'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
@@ -24,12 +24,6 @@ function log()
 {
 	if [[ ${verbose} -gt 0 ]]; then
 	echo "$1"
-	fi
-}
-function logn()
-{
-	if [[ ${verbose} -gt 0 ]]; then
-	echo -n "$1"
 	fi
 }
 
@@ -58,7 +52,7 @@ sed Dockerfile \
 	> Dockerfile.2
 
 # pull maven (if not present, or forced, or new version in dockerfile)
-if [[ ! -f apache-maven-${MAVEN_VERSION}-bin.tar.gz ]] || [[ $(diff -U 0 --suppress-common-lines -b Dockerfile.2 Dockerfile) ]] || [[ ${pullAssets} -eq 1 ]]; then
+if [[ ! -f apache-maven-${MAVEN_VERSION}-bin.tar.gz ]] || [[ $(diff -U 0 --suppress-common-lines -b Dockerfile.2 Dockerfile) ]] || [[ ${PULL_ASSETS} -eq 1 ]]; then
 	mv -f Dockerfile.2 Dockerfile
 	curl -sSL -O https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip
 	curl -sSL -O http://mirror.csclub.uwaterloo.ca/apache/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz

--- a/codeready-workspaces-plugin-java11/get-sources.sh
+++ b/codeready-workspaces-plugin-java11/get-sources.sh
@@ -11,7 +11,10 @@ while [[ "$#" -gt 0 ]]; do
 	'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
 	'-f'|'--force-build') forceBuild=1; shift 0;;
 	'-p'|'--pull-assets') pullAssets=1; shift 0;;
+	'-a'|'--publish-assets') exit 0; shift 0;;
+	'-d'|'--delete-assets') exit 0; shift 0;;
 	'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
+	'-v') CSV_VERSION="$2"; shift 1;;
 	*) JOB_BRANCH="$1"; shift 0;;
 	esac
 	shift 1

--- a/codeready-workspaces-plugin-java8-openj9/build/build.sh
+++ b/codeready-workspaces-plugin-java8-openj9/build/build.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -xe
+
+# Copyright (c) 2018-2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+usage () {
+    echo "
+Usage:   $0 -v [CRW CSV_VERSION] -n [GITHUB_RELEASE_NAME]
+Example: $0 -v 2.y.0 -n plugin-java8-openj9
+"
+    exit
+}
+
+if [[ $# -lt 1 ]]; then usage; fi
+
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    '-v') CSV_VERSION="$2"; shift 1;;
+    '-n') ASSET_NAME="$2"; shift 1;;
+    '--help'|'-h') usage;;
+  esac
+  shift 1
+done
+
+./../codeready-workspaces-plugin-java8/build/build_node10.sh -v ${CSV_VERSION} -n ${ASSET_NAME}
+./../codeready-workspaces-plugin-java8/build/build_python.sh -v ${CSV_VERSION} -n ${ASSET_NAME}

--- a/codeready-workspaces-plugin-java8-openj9/build/build.sh
+++ b/codeready-workspaces-plugin-java8-openj9/build/build.sh
@@ -13,8 +13,8 @@
 
 usage () {
     echo "
-Usage:   $0 -v [CRW CSV_VERSION] -n [GITHUB_RELEASE_NAME]
-Example: $0 -v 2.y.0 -n plugin-java8-openj9
+Usage:   $0 -v [CRW CSV_VERSION] -n [ASSET_NAME]
+Example: $0 -v 2.y.0 -n java8-openj9
 "
     exit
 }

--- a/codeready-workspaces-plugin-java8-openj9/get-sources.sh
+++ b/codeready-workspaces-plugin-java8-openj9/get-sources.sh
@@ -5,16 +5,27 @@ scratchFlag=""
 JOB_BRANCH=""
 doRhpkgContainerBuild=1
 forceBuild=0
-pullAssets=0
+PULL_ASSETS=0
+DELETE_ASSETS=0
+PUBLISH_ASSETS=0
 generateDockerfileLABELs=1
 targetFlag=""
+UPSTREAM_JOB_NAME="crw-deprecated_${JOB_BRANCH}" # eg., 2.4
+# maven - install 3.6 from https://maven.apache.org/download.cgi
+MAVEN_VERSION="3.6.3"
+LOMBOK_VERSION="1.18.18"
+ASSET_NAME="java8-openj9"
+
 while [[ "$#" -gt 0 ]]; do
   case $1 in
 	'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
 	'-f'|'--force-build') forceBuild=1; shift 0;;
-	'-p'|'--pull-assets') pullAssets=1; shift 0;;
+	'-d'|'--delete-assets') DELETE_ASSETS=1; shift 0;;
+	'-a'|'--publish-assets') PUBLISH_ASSETS=1; shift 0;;
+	'-p'|'--pull-assets') PULL_ASSETS=1; shift 0;;
 	'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
 	'-t'|'--target') targetFlag="--target $2"; shift 1;;
+	'-v') CSV_VERSION="$2"; shift 1;;
 	*) JOB_BRANCH="$1"; shift 0;;
   esac
   shift 1
@@ -26,12 +37,22 @@ function log()
 	echo "$1"
   fi
 }
-function logn()
-{
-  if [[ ${verbose} -gt 0 ]]; then
-	echo -n "$1"
-  fi
-}
+
+if [[ ! -x ./uploadAssetsToGHRelease.sh ]]; then 
+    curl -sSLO "https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/${MIDSTM_BRANCH}/product/uploadAssetsToGHRelease.sh" && chmod +x uploadAssetsToGHRelease.sh
+fi
+
+if [[ ${DELETE_ASSETS} -eq 1 ]]; then
+	log "[INFO] Delete Previous GitHub Releases:"
+	./uploadAssetsToGHRelease.sh --delete-assets -v "${CSV_VERSION}" -n ${ASSET_NAME}
+	exit 0;
+fi
+
+if [[ ${PUBLISH_ASSETS} -eq 1 ]]; then
+	log "[INFO] Build Assets and Publish to GitHub Releases:"
+	./build/build.sh -v ${CSV_VERSION} -n ${ASSET_NAME}
+	exit 0;
+fi 
 
 # if not set, compute from current branch
 if [[ ! ${JOB_BRANCH} ]]; then 
@@ -39,148 +60,12 @@ if [[ ! ${JOB_BRANCH} ]]; then
 	if [[ ${JOB_BRANCH} == "2" ]]; then JOB_BRANCH="2.x"; fi
 fi
 
-UPSTREAM_JOB_NAME="crw-deprecated_${JOB_BRANCH}" # eg., 2.4
-
-jenkinsURL=""
-checkJenkinsURL() {
-	checkURL="$1"
-	if [[ ! $(curl -sSLI ${checkURL} 2>&1 | grep -E "404|Not Found|Failed to connect|No route to host|Could not resolve host|Connection refused") ]]; then
-		jenkinsURL="$checkURL"
-	else
-		jenkinsURL=""
-	fi
-}
-# try local env var first
-if [[ ${JENKINS_URL} ]]; then 
-	checkJenkinsURL "${JENKINS_URL}job/CRW_CI/job/${UPSTREAM_JOB_NAME}"
-fi
-# new jenkins & path
-if [[ ! $jenkinsURL ]]; then
-	checkJenkinsURL "https://main-jenkins-csb-crwqe.apps.ocp4.prod.psi.redhat.com/job/CRW_CI/job/${UPSTREAM_JOB_NAME}"
-fi
-# old jenkins & path
-if [[ ! $jenkinsURL ]]; then
-	checkJenkinsURL "https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/${UPSTREAM_JOB_NAME}"
-fi
-if [[ ! $jenkinsURL ]]; then
-	echo "[ERROR] Cannot resolve artifact(s) for this build. Must abort!"
-	exit 1
-fi
-log "[INFO] Using Brew with ${targetFlag}" 
-theTarGzs="
-lastSuccessfulBuild/artifact/codeready-workspaces-deprecated/node10/target/codeready-workspaces-stacks-language-servers-dependencies-node10-s390x.tar.gz
-lastSuccessfulBuild/artifact/codeready-workspaces-deprecated/python/target/codeready-workspaces-stacks-language-servers-dependencies-python-s390x.tar.gz
-lastSuccessfulBuild/artifact/codeready-workspaces-deprecated/node10/target/codeready-workspaces-stacks-language-servers-dependencies-node10-ppc64le.tar.gz
-lastSuccessfulBuild/artifact/codeready-workspaces-deprecated/python/target/codeready-workspaces-stacks-language-servers-dependencies-python-ppc64le.tar.gz
-"
-lastSuccessfulURL="${jenkinsURL}/lastSuccessfulBuild/api/xml?xpath=/workflowRun/" # id
-# maven - install 3.6 from https://maven.apache.org/download.cgi
-MAVEN_VERSION="3.6.3"
-
-LOMBOK_VERSION="1.18.18"
-
-LABELs=""
-function addLabel () {
-	addLabeln "${1}" "${2}" "${3}"
-	echo ""
-}
-function addLabeln () {
-	LABEL_VAR=$1
-	if [[ "${2}" ]]; then LABEL_VAL=$2; else LABEL_VAL="${!LABEL_VAR}"; fi
-	if [[ "${3}" ]]; then PREFIX=$3; else PREFIX="  << "; fi
-	if [[ ${generateDockerfileLABELs} -eq 1 ]]; then 
-		LABELs="${LABELs} ${LABEL_VAR}=\"${LABEL_VAL}\""
-	fi
-	echo -n "${PREFIX}${LABEL_VAL}"
-}
-
-function parseCommitLog () 
-{
-	# Update from Jenkins ::
-	# crw_master ::
-	# Build #246 (2019-02-26 04:23:36 EST) ::
-	# che-ls-jdt @ 288b75765175d368480a688c8f3a77ce4758c72d (0.0.3) ::
-	# che @ f34f4c6c82de35081351e0b0686b1ae6589735d4 (6.19.0-SNAPSHOT) ::
-	# codeready-workspaces @ 184e24bee5bd923b733fa8c9f4b055a9caad40d2 (1.1.0.GA) ::
-	# codeready-workspaces-deprecated @ 620a53c5b0a1bbc02ba68e96be94ec3b932c9bee ::
-	# codeready-workspaces-assembly-main.tar.gz
-	# codeready-workspaces-stacks-language-servers-dependencies-bayesian.tar.gz
-	# codeready-workspaces-stacks-language-servers-dependencies-node.tar.gz
-	tarballs=""
-	OTHER=""
-	JOB_NAME=""
-	GHE="https://github.com/eclipse/"
-	GHR="https://github.com/redhat-developer/"
-	while [[ "$#" -gt 0 ]]; do
-	  case $1 in
-		'crw_master'|'crw_stable-branch'|'crw-deprecated_'*) JOB_NAME="$1"; shift 2;;
-		'Build'*) BUILD_NUMBER="$2"; BUILD_NUMBER=${BUILD_NUMBER#\#}; shift 6;; # trim # from the number, ignore timestamp
-		'che-dev'|'che-parent'|'che-lib'|'che-ls-jdt'|'che') 
-			sha="$3"; addLabeln "git.commit.eclipse__${1}" "${GHE}${1}/commit/${sha:0:7}"; addLabel "pom.version.eclipse__${1}" "${4:1:-1}" " "; shift 5;;
-		'codeready-workspaces')
-			sha="$3"; addLabeln "git.commit.redhat-developer__${1}" "${GHR}${1}/commit/${sha:0:7}"; addLabel "pom.version.redhat-developer__${1}" "${4:1:-1}" " "; shift 5;;
-		'codeready-workspaces-deprecated')
-			sha="$3"; addLabeln "git.commit.redhat-developer__${1}" "${GHR}${1}/commit/${sha:0:7}"; shift 4;;
-		*'tar.gz') tarballs="${tarballs} $1"; shift 1;;
-		*) OTHER="${OTHER} $1"; shift 1;; 
-	  esac
-	done
-	if [[ $JOB_NAME ]]; then
-		jenkinsServer="${jenkinsURL%/job/*}"
-		addLabel "jenkins.build.url" "${jenkinsServer}/view/CRW_CI/view/Pipelines/job/${JOB_NAME}/${BUILD_NUMBER}/"
-		for t in $tarballs; do
-			addLabel "jenkins.artifact.url" "${jenkinsServer}/view/CRW_CI/view/Pipelines/job/${JOB_NAME}/${BUILD_NUMBER}/artifact/**/${t}" "	 ++ "
-		done
-	else
-		addLabel "jenkins.tarball.url" "${jenkinsServer}/view/CRW_CI/view/Pipelines #${BUILD_NUMBER} /${tarballs}"
-	fi
-}
-
-function insertLabels () {
-	DOCKERFILE=$1
-	# trim off the footer of the file
-	mv ${DOCKERFILE} ${DOCKERFILE}.bak
-	sed '/.*insert generated LABELs below this line.*/q' ${DOCKERFILE}.bak > ${DOCKERFILE}
-	# insert marker
-	if [[ ! $(cat ${DOCKERFILE}.bak | grep "insert generated LABELs below this line") ]]; then 
-		echo "" >> ${DOCKERFILE}
-		echo "" >> ${DOCKERFILE}
-		echo "# insert generated LABELs below this line" >> ${DOCKERFILE}
-	fi
-	# add new labels
-	echo "LABEL \\" >> ${DOCKERFILE}
-	for l in $LABELs; do
-		echo "	  ${l} \\" >> ${DOCKERFILE}
-	done
-	echo "	  jenkins.build.number=\"${BUILD_NUMBER}\"" >> ${DOCKERFILE}
-	rm -f ${DOCKERFILE}.bak
-}
-
-function getFingerprints ()
-{
-	outputFile=$1
-	latestFingerprint="$(curl -L ${jenkinsURL}/lastSuccessfulBuild/fingerprints/ 2>&1 | grep ${outputFile} | sed -e "s#.\+/fingerprint/\([0-9a-f]\+\)/\".\+#\1#")"
-	currentFingerprint="$(cat sources | grep ${outputFile} | sed -e "s#\([0-9a-f]\+\) .\+#\1#")"
-}
-
-# get the public URL for the tarball(s)
-outputFiles=""
-
 #### override any existing tarballs with newer ones from Jenkins build
-for theTarGz in ${theTarGzs}; do
-	outputFile=${theTarGz##*/}
-	log "[INFO] Download ${jenkinsURL}/${theTarGz}:"
-	rm -f ${outputFile}
-	getFingerprints ${outputFile}
-	if [[ ! ${latestFingerprint} ]]; then 
-		echo "[WARNING] Cannot resolve artifact fingerprints for ${outputFile}"
-	fi
-	
-	if [[ "${latestFingerprint}" != "${currentFingerprint}" ]] || [[ ! -f ${outputFile} ]] || [[ ${pullAssets} -eq 1 ]]; then 
-		curl -L -o ${outputFile} ${jenkinsURL}/${theTarGz}
-		outputFiles="${outputFiles} ${outputFile}"
-	fi
-done
+log "[INFO] Download Assets:"
+./uploadAssetsToGHRelease.sh --pull-assets -v "${CSV_VERSION}" -n ${ASSET_NAME}
+
+#get names of the downloaded tarballs
+theTarGzs="$(ls *.tar.gz)"
 
 # update Dockerfile to record version we expect for MAVEN_VERSION
 sed Dockerfile \
@@ -189,60 +74,49 @@ sed Dockerfile \
 	> Dockerfile.2
 
 # pull maven (if not present, or forced, or new version in dockerfile)
-if [[ ! -f apache-maven-${MAVEN_VERSION}-bin.tar.gz ]] || [[ $(diff -U 0 --suppress-common-lines -b Dockerfile.2 Dockerfile) ]] || [[ ${pullAssets} -eq 1 ]]; then
+if [[ ! -f apache-maven-${MAVEN_VERSION}-bin.tar.gz ]] || [[ $(diff -U 0 --suppress-common-lines -b Dockerfile.2 Dockerfile) ]] || [[ ${PULL_ASSETS} -eq 1 ]]; then
 	mv -f Dockerfile.2 Dockerfile
 	curl -sSL -O http://mirror.csclub.uwaterloo.ca/apache/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
 	curl -sSL -O https://projectlombok.org/downloads/lombok-${LOMBOK_VERSION}.jar
 fi
-outputFiles="apache-maven-${MAVEN_VERSION}-bin.tar.gz lombok-${LOMBOK_VERSION}.jar ${outputFiles}"
+outputFiles="apache-maven-${MAVEN_VERSION}-bin.tar.gz lombok-${LOMBOK_VERSION}.jar ${theTarGzs}"
 
-if [[ ${outputFiles} ]]; then
-	log "[INFO] Upload new sources:${outputFiles}"
-	rhpkg new-sources ${outputFiles}
-	log "[INFO] Commit new sources from:${outputFiles}"
-	field=id; ID=$(curl -L -s -S ${lastSuccessfulURL}${field} | sed -e "s#<${field}>\(.\+\)</${field}>#\1#" -e "s#&lt;br/&gt; #\n#g" -e "s#\&lt;a.\+/a\&gt;##g")
-	if [[ $(echo $ID | grep -E "404 Not Found|ERROR 404|Application is not available") ]]; then 
-		echo $ID
-		echo "[ERROR] Problem loading ID from ${lastSuccessfulURL}${field} :: NOT FOUND!"
-		exit 1;
-	fi
-	COMMIT_MSG="Update from Jenkins :: Maven ${MAVEN_VERSION} + ${UPSTREAM_JOB_NAME} :: ${ID}
-::${outputFiles}"
-	parseCommitLog ${COMMIT_MSG}
-	insertLabels Dockerfile
-	if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]] ;then 
-		log "[INFO] No new sources, so nothing to build."
-	elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
-		log "[INFO] Push change:"
-		git pull; git push; git status -s || true
-	fi
-	if [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
-		echo "[INFO] #1 Trigger container-build in current branch: rhpkg container-build ${targetFlag} ${scratchFlag}"
-		git status || true
-		tmpfile=$(mktemp) && rhpkg container-build ${targetFlag} ${scratchFlag} --nowait | tee 2>&1 $tmpfile
-		taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
-		ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
-		if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
+log "[INFO] Upload new sources:${theTarGzs}"
+rhpkg new-sources ${theTarGzs}
+log "[INFO] Commit new sources from:${theTarGzs}"
+COMMIT_MSG="Update from GitHub :: Maven ${MAVEN_VERSION} + ${UPSTREAM_JOB_NAME} ::${theTarGzs}"
+if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]] ;then 
+	log "[INFO] No new sources, so nothing to build."
+elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
+	log "[INFO] Push change:"
+	git pull; git push; git status -s || true
+fi
+if [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
+	echo "[INFO] #1 Trigger container-build in current branch: rhpkg container-build ${targetFlag} ${scratchFlag}"
+	git status || true
+	tmpfile=$(mktemp) && rhpkg container-build ${targetFlag} ${scratchFlag} --nowait | tee 2>&1 $tmpfile
+	taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
+	ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
+	if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
 
 $ERRORS
 
 "; exit 1; fi
-	fi
+fi
+
+if [[ ${forceBuild} -eq 1 ]]; then
+	echo "[INFO] #2 Trigger container-build in current branch: rhpkg container-build ${targetFlag} ${scratchFlag}"
+	git status || true
+	tmpfile=$(mktemp) && rhpkg container-build ${targetFlag} ${scratchFlag} --nowait | tee 2>&1 $tmpfile
+	taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
+	ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
+	if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
+
+$ERRORS
+
+"; exit 1; fi
 else
-	if [[ ${forceBuild} -eq 1 ]]; then
-		echo "[INFO] #2 Trigger container-build in current branch: rhpkg container-build ${targetFlag} ${scratchFlag}"
-		git status || true
-		tmpfile=$(mktemp) && rhpkg container-build ${targetFlag} ${scratchFlag} --nowait | tee 2>&1 $tmpfile
-		taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
-		ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
-		if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
-
-$ERRORS
-
-"; exit 1; fi
-	else
-		log "[INFO] No new sources, so nothing to build."
-	fi
+	log "[INFO] No new sources, so nothing to build."
 fi
 
 # cleanup

--- a/codeready-workspaces-plugin-java8-openj9/get-sources.sh
+++ b/codeready-workspaces-plugin-java8-openj9/get-sources.sh
@@ -81,45 +81,43 @@ if [[ ${PULL_ASSETS} -eq 1 ]]; then
 	fi
 	outputFiles="apache-maven-${MAVEN_VERSION}-bin.tar.gz lombok-${LOMBOK_VERSION}.jar ${theTarGzs}"
 
-	log "[INFO] Upload new sources:${theTarGzs}"
-	rhpkg new-sources ${theTarGzs}
-	log "[INFO] Commit new sources from:${theTarGzs}"
-	COMMIT_MSG="Update from GitHub :: Maven ${MAVEN_VERSION} + ${ASSET_NAME} Assets ::${theTarGzs}"
+	log "[INFO] Upload new sources:${outputFiles}"
+	rhpkg new-sources ${outputFiles}
+	log "[INFO] Commit new sources from:${outputFiles}"
+	COMMIT_MSG="Update from GitHub :: Maven ${MAVEN_VERSION} + ${ASSET_NAME} Assets ::${outputFiles}"
 	if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]] ;then 
 		log "[INFO] No new sources, so nothing to build."
 	elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
 		log "[INFO] Push change:"
 		git pull; git push; git status -s || true
 	fi
-fi
-
-if [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
-	echo "[INFO] #1 Trigger container-build in current branch: rhpkg container-build ${targetFlag} ${scratchFlag}"
-	git status || true
-	tmpfile=$(mktemp) && rhpkg container-build ${targetFlag} ${scratchFlag} --nowait | tee 2>&1 $tmpfile
-	taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
-	ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
-	if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
+	if [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
+		echo "[INFO] #1 Trigger container-build in current branch: rhpkg container-build ${targetFlag} ${scratchFlag}"
+		git status || true
+		tmpfile=$(mktemp) && rhpkg container-build ${targetFlag} ${scratchFlag} --nowait | tee 2>&1 $tmpfile
+		taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
+		ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
+		if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
 
 $ERRORS
 
 "; exit 1; fi
-fi
-
-if [[ ${forceBuild} -eq 1 ]]; then
-	echo "[INFO] #2 Trigger container-build in current branch: rhpkg container-build ${targetFlag} ${scratchFlag}"
-	git status || true
-	tmpfile=$(mktemp) && rhpkg container-build ${targetFlag} ${scratchFlag} --nowait | tee 2>&1 $tmpfile
-	taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
-	ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
-	if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
-
-$ERRORS
-
-"; exit 1; fi
+	fi
 else
-	log "[INFO] No new sources, so nothing to build."
-fi
+	if [[ ${forceBuild} -eq 1 ]]; then
+		echo "[INFO] #2 Trigger container-build in current branch: rhpkg container-build ${targetFlag} ${scratchFlag}"
+		git status || true
+		tmpfile=$(mktemp) && rhpkg container-build ${targetFlag} ${scratchFlag} --nowait | tee 2>&1 $tmpfile
+		taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
+		ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
+		if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
 
+$ERRORS
+
+"; exit 1; fi
+	else
+		log "[INFO] No new sources, so nothing to build."
+	fi
+fi
 # cleanup
 rm -fr Dockerfile.2

--- a/codeready-workspaces-plugin-java8-openj9/get-sources.sh
+++ b/codeready-workspaces-plugin-java8-openj9/get-sources.sh
@@ -10,7 +10,6 @@ DELETE_ASSETS=0
 PUBLISH_ASSETS=0
 generateDockerfileLABELs=1
 targetFlag=""
-UPSTREAM_JOB_NAME="crw-deprecated_${JOB_BRANCH}" # eg., 2.4
 # maven - install 3.6 from https://maven.apache.org/download.cgi
 MAVEN_VERSION="3.6.3"
 LOMBOK_VERSION="1.18.18"
@@ -85,7 +84,7 @@ if [[ ${PULL_ASSETS} -eq 1 ]]; then
 	log "[INFO] Upload new sources:${theTarGzs}"
 	rhpkg new-sources ${theTarGzs}
 	log "[INFO] Commit new sources from:${theTarGzs}"
-	COMMIT_MSG="Update from GitHub :: Maven ${MAVEN_VERSION} + ${UPSTREAM_JOB_NAME} ::${theTarGzs}"
+	COMMIT_MSG="Update from GitHub :: Maven ${MAVEN_VERSION} + ${ASSET_NAME} Assets ::${theTarGzs}"
 	if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]] ;then 
 		log "[INFO] No new sources, so nothing to build."
 	elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then

--- a/codeready-workspaces-plugin-java8-openj9/get-sources.sh
+++ b/codeready-workspaces-plugin-java8-openj9/get-sources.sh
@@ -60,37 +60,40 @@ if [[ ! ${JOB_BRANCH} ]]; then
 	if [[ ${JOB_BRANCH} == "2" ]]; then JOB_BRANCH="2.x"; fi
 fi
 
-#### override any existing tarballs with newer ones from Jenkins build
-log "[INFO] Download Assets:"
-./uploadAssetsToGHRelease.sh --pull-assets -v "${CSV_VERSION}" -n ${ASSET_NAME}
+if [[ ${PULL_ASSETS} -eq 1 ]]; then
+	#### override any existing tarballs with newer ones from Jenkins build
+	log "[INFO] Download Assets:"
+	./uploadAssetsToGHRelease.sh --pull-assets -v "${CSV_VERSION}" -n ${ASSET_NAME}
 
-#get names of the downloaded tarballs
-theTarGzs="$(ls *.tar.gz)"
+	#get names of the downloaded tarballs
+	theTarGzs="$(ls *.tar.gz)"
 
-# update Dockerfile to record version we expect for MAVEN_VERSION
-sed Dockerfile \
-	-e "s#MAVEN_VERSION=\"\([^\"]\+\)\"#MAVEN_VERSION=\"${MAVEN_VERSION}\"#" \
-	-e "s#LOMBOK_VERSION=\"\([^\"]\+\)\"#LOMBOK_VERSION=\"${LOMBOK_VERSION}\"#" \
-	> Dockerfile.2
+	# update Dockerfile to record version we expect for MAVEN_VERSION
+	sed Dockerfile \
+		-e "s#MAVEN_VERSION=\"\([^\"]\+\)\"#MAVEN_VERSION=\"${MAVEN_VERSION}\"#" \
+		-e "s#LOMBOK_VERSION=\"\([^\"]\+\)\"#LOMBOK_VERSION=\"${LOMBOK_VERSION}\"#" \
+		> Dockerfile.2
 
-# pull maven (if not present, or forced, or new version in dockerfile)
-if [[ ! -f apache-maven-${MAVEN_VERSION}-bin.tar.gz ]] || [[ $(diff -U 0 --suppress-common-lines -b Dockerfile.2 Dockerfile) ]] || [[ ${PULL_ASSETS} -eq 1 ]]; then
-	mv -f Dockerfile.2 Dockerfile
-	curl -sSL -O http://mirror.csclub.uwaterloo.ca/apache/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
-	curl -sSL -O https://projectlombok.org/downloads/lombok-${LOMBOK_VERSION}.jar
+	# pull maven (if not present, or forced, or new version in dockerfile)
+	if [[ ! -f apache-maven-${MAVEN_VERSION}-bin.tar.gz ]] || [[ $(diff -U 0 --suppress-common-lines -b Dockerfile.2 Dockerfile) ]] || [[ ${PULL_ASSETS} -eq 1 ]]; then
+		mv -f Dockerfile.2 Dockerfile
+		curl -sSL -O http://mirror.csclub.uwaterloo.ca/apache/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
+		curl -sSL -O https://projectlombok.org/downloads/lombok-${LOMBOK_VERSION}.jar
+	fi
+	outputFiles="apache-maven-${MAVEN_VERSION}-bin.tar.gz lombok-${LOMBOK_VERSION}.jar ${theTarGzs}"
+
+	log "[INFO] Upload new sources:${theTarGzs}"
+	rhpkg new-sources ${theTarGzs}
+	log "[INFO] Commit new sources from:${theTarGzs}"
+	COMMIT_MSG="Update from GitHub :: Maven ${MAVEN_VERSION} + ${UPSTREAM_JOB_NAME} ::${theTarGzs}"
+	if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]] ;then 
+		log "[INFO] No new sources, so nothing to build."
+	elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
+		log "[INFO] Push change:"
+		git pull; git push; git status -s || true
+	fi
 fi
-outputFiles="apache-maven-${MAVEN_VERSION}-bin.tar.gz lombok-${LOMBOK_VERSION}.jar ${theTarGzs}"
 
-log "[INFO] Upload new sources:${theTarGzs}"
-rhpkg new-sources ${theTarGzs}
-log "[INFO] Commit new sources from:${theTarGzs}"
-COMMIT_MSG="Update from GitHub :: Maven ${MAVEN_VERSION} + ${UPSTREAM_JOB_NAME} ::${theTarGzs}"
-if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]] ;then 
-	log "[INFO] No new sources, so nothing to build."
-elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
-	log "[INFO] Push change:"
-	git pull; git push; git status -s || true
-fi
 if [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
 	echo "[INFO] #1 Trigger container-build in current branch: rhpkg container-build ${targetFlag} ${scratchFlag}"
 	git status || true

--- a/codeready-workspaces-plugin-java8-openj9/get-sources.sh
+++ b/codeready-workspaces-plugin-java8-openj9/get-sources.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -xe
-# script to get tarball(s) from Jenkins, plus additional dependencies as needed
+# script to get tarball(s) from GitHub Releases, plus additional dependencies as needed
 verbose=1
 scratchFlag=""
 JOB_BRANCH=""
@@ -60,7 +60,7 @@ if [[ ! ${JOB_BRANCH} ]]; then
 fi
 
 if [[ ${PULL_ASSETS} -eq 1 ]]; then
-	#### override any existing tarballs with newer ones from Jenkins build
+	#### override any existing tarballs with newer ones from asset build
 	log "[INFO] Download Assets:"
 	./uploadAssetsToGHRelease.sh --pull-assets -v "${CSV_VERSION}" -n ${ASSET_NAME}
 
@@ -84,7 +84,7 @@ if [[ ${PULL_ASSETS} -eq 1 ]]; then
 	log "[INFO] Upload new sources:${outputFiles}"
 	rhpkg new-sources ${outputFiles}
 	log "[INFO] Commit new sources from:${outputFiles}"
-	COMMIT_MSG="Update from GitHub :: Maven ${MAVEN_VERSION} + ${ASSET_NAME} Assets ::${outputFiles}"
+	COMMIT_MSG="chore: update from GH ${ASSET_NAME} assets :: ${outputFiles}"
 	if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]] ;then 
 		log "[INFO] No new sources, so nothing to build."
 	elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then

--- a/codeready-workspaces-plugin-java8/build/build.sh
+++ b/codeready-workspaces-plugin-java8/build/build.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -xe
+
+# Copyright (c) 2018-2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+usage () {
+    echo "
+Usage:   $0 -v [CRW CSV_VERSION] -n [GITHUB_RELEASE_NAME]
+Example: $0 -v 2.y.0 -n plugin-java8-openj9
+"
+    exit
+}
+
+if [[ $# -lt 1 ]]; then usage; fi
+
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    '-v') CSV_VERSION="$2"; shift 1;;
+    '-n') ASSET_NAME="$2"; shift 1;;
+    '--help'|'-h') usage;;
+  esac
+  shift 1
+done
+
+./build/build_node10.sh -v ${CSV_VERSION} -n ${ASSET_NAME}
+./build/build_python.sh -v ${CSV_VERSION} -n ${ASSET_NAME}

--- a/codeready-workspaces-plugin-java8/build/build.sh
+++ b/codeready-workspaces-plugin-java8/build/build.sh
@@ -13,8 +13,8 @@
 
 usage () {
     echo "
-Usage:   $0 -v [CRW CSV_VERSION] -n [GITHUB_RELEASE_NAME]
-Example: $0 -v 2.y.0 -n plugin-java8-openj9
+Usage:   $0 -v [CRW CSV_VERSION] -n [ASSET_NAME]
+Example: $0 -v 2.y.0 -n java8-openj9
 "
     exit
 }

--- a/codeready-workspaces-plugin-java8/build/build_node10.sh
+++ b/codeready-workspaces-plugin-java8/build/build_node10.sh
@@ -1,0 +1,74 @@
+#!/bin/bash -xe
+
+# Copyright (c) 2018-2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+# shellcheck disable=SC2155
+export SCRIPT_DIR=$(cd "$(dirname "$0")" || exit; pwd)
+export NODEJS_IMAGE="registry.access.redhat.com/ubi8/nodejs-10:1-114"
+export NODEMON_VERSION=1.19.3  # find latest version: https://www.npmjs.com/package/nodemon
+export TYPERSCRIPT_VERSION=3.4.5  # find latest version: https://www.npmjs.com/package/typescript
+export TYPESCRIPT_LS_VERSION=0.3.7  # find latest version: https://www.npmjs.com/package/typescript-language-server
+
+usage () {
+    echo "
+Usage:   $0 -v [CRW CSV_VERSION] -n [GITHUB_RELEASE_NAME]
+Example: $0 -v 2.y.0 -n plugin-java8-openj9
+"
+    exit
+}
+
+if [[ $# -lt 1 ]]; then usage; fi
+
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    '-v') CSV_VERSION="$2"; shift 1;;
+    '-n') ASSET_NAME="$2"; shift 1;;
+    '--help'|'-h') usage;;
+  esac
+  shift 1
+done
+
+cd "$SCRIPT_DIR"
+[[ -e target ]] && rm -Rf target
+
+echo ""
+echo "CodeReady Workspaces :: Stacks :: Language Servers :: Node 10 Dependencies"
+echo ""
+
+mkdir -p target/nodejs-ls
+
+PODMAN=$(command -v podman || true)
+if [[ ! -x $PODMAN ]]; then
+  echo "[WARNING] podman is not installed."
+ PODMAN=$(command -v docker || true)
+  if [[ ! -x $PODMAN ]]; then
+    echo "[ERROR] docker is not installed. Aborting."; exit 1
+  fi
+fi
+
+ARCH="$(uname -m)"
+if [[ ! ${WORKSPACE} ]]; then WORKSPACE=/tmp; fi
+tarball="${WORKSPACE}/codeready-workspaces-stacks-language-servers-dependencies-node10-${ARCH}.tar.gz"
+
+${PODMAN} run --rm -v "$SCRIPT_DIR"/target/nodejs-ls:/node_modules -u root ${NODEJS_IMAGE} sh -c "
+    npm install --prefix /node_modules nodemon@${NODEMON_VERSION} typescript@${TYPERSCRIPT_VERSION} typescript-language-server@${TYPESCRIPT_LS_VERSION}
+    chmod -R 777 /node_modules
+    "
+tar -czf "${tarball}" -C target/nodejs-ls .
+
+# upload the binary to GH
+if [[ ! -x ./uploadAssetsToGHRelease.sh ]]; then 
+    curl -sSLO "https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/${MIDSTM_BRANCH}/product/uploadAssetsToGHRelease.sh" && chmod +x uploadAssetsToGHRelease.sh
+fi
+./uploadAssetsToGHRelease.sh --publish-assets -v "${CSV_VERSION}" -b "${MIDSTM_BRANCH}" -n ${ASSET_NAME} "${tarball}"
+
+${PODMAN} rmi -f ${NODEJS_IMAGE}

--- a/codeready-workspaces-plugin-java8/build/build_node10.sh
+++ b/codeready-workspaces-plugin-java8/build/build_node10.sh
@@ -20,8 +20,8 @@ export TYPESCRIPT_LS_VERSION=0.3.7  # find latest version: https://www.npmjs.com
 
 usage () {
     echo "
-Usage:   $0 -v [CRW CSV_VERSION] -n [GITHUB_RELEASE_NAME]
-Example: $0 -v 2.y.0 -n plugin-java8-openj9
+Usage:   $0 -v [CRW CSV_VERSION] -n [ASSET_NAME]
+Example: $0 -v 2.y.0 -n java8-openj9
 "
     exit
 }

--- a/codeready-workspaces-plugin-java8/build/build_python.sh
+++ b/codeready-workspaces-plugin-java8/build/build_python.sh
@@ -1,0 +1,89 @@
+#!/bin/bash -xe
+
+# Copyright (c) 2018-2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+# shellcheck disable=SC2155
+export SCRIPT_DIR=$(cd "$(dirname "$0")" || exit; pwd)
+export PYTHON_LS_VERSION=0.36.1
+export PYTHON_IMAGE="registry.access.redhat.com/ubi8/python-38:1"
+
+usage () {
+    echo "
+Usage:   $0 -v [CRW CSV_VERSION] -n [GITHUB_RELEASE_NAME]
+Example: $0 -v 2.y.0 -n plugin-java8-openj9
+"
+    exit
+}
+
+if [[ $# -lt 1 ]]; then usage; fi
+
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    '-v') CSV_VERSION="$2"; shift 1;;
+    '-n') ASSET_NAME="$2"; shift 1;;
+    '--help'|'-h') usage;;
+  esac
+  shift 1
+done
+
+cd "$SCRIPT_DIR"
+[[ -e target ]] && rm -Rf target
+
+PODMAN=$(command -v podman || true)
+if [[ ! -x $PODMAN ]]; then
+  echo "[WARNING] podman is not installed."
+ PODMAN=$(command -v docker || true)
+  if [[ ! -x $PODMAN ]]; then
+    echo "[ERROR] docker is not installed. Aborting."; exit 1
+  fi
+fi
+
+#Python build
+echo ""
+echo "CodeReady Workspaces :: Stacks :: Language Servers :: Python Dependencies"
+echo ""
+
+mkdir -p target/python-ls
+
+ARCH="$(uname -m)"
+if [[ ! ${WORKSPACE} ]]; then WORKSPACE=/tmp; fi
+tarball="${WORKSPACE}/codeready-workspaces-stacks-language-servers-dependencies-python-${ARCH}.tar.gz"
+
+${PODMAN} run --rm -v "$SCRIPT_DIR"/target/python-ls:/tmp/python -u root ${PYTHON_IMAGE} sh -c "
+    /usr/bin/python3 --version && /usr/bin/python3 -m pip --version && \
+    /usr/bin/python3 -m pip install -q --upgrade  --no-warn-script-location pip && \
+    /usr/bin/python3 -m pip install -q --no-warn-script-location python-language-server[all]==${PYTHON_LS_VERSION} ptvsd jedi ipykernel jupyter wrapt --prefix=/tmp/python && \
+    /usr/bin/python3 -m pip install -q --no-warn-script-location pylint --prefix=/tmp/python && \
+    chmod -R 777 /tmp/python && \
+    # fix exec line in pylint executable to use valid python interpreter - replace /opt/app-root/ with /usr/
+    for d in \$(find /tmp/python/bin -type f); do sed -i \${d} -r -e 's#/opt/app-root/#/usr/#'; done && 
+    export PATH=\${PATH}:/tmp/python/bin
+    ls -1 /tmp/python/bin
+    # cat /tmp/python/bin/pylint
+    mkdir -p /home/jboss;
+    cd /home/jboss;
+    /usr/bin/python3 -m venv .venv;
+    source .venv/bin/activate;
+    pip install -U pylint ipykernel jupyter;
+    python3 -m ipykernel install --name=.venv;
+    deactivate;
+    mv .venv /tmp/python/
+    "
+tar -czf "${tarball}" -C target/python-ls .
+
+# upload the binary to GH
+if [[ ! -x ./uploadAssetsToGHRelease.sh ]]; then 
+    curl -sSLO "https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/${MIDSTM_BRANCH}/product/uploadAssetsToGHRelease.sh" && chmod +x uploadAssetsToGHRelease.sh
+fi
+./uploadAssetsToGHRelease.sh --publish-assets -v "${CSV_VERSION}" -b "${MIDSTM_BRANCH}" -n ${ASSET_NAME} "${tarball}"
+
+${PODMAN} rmi -f ${PYTHON_IMAGE}

--- a/codeready-workspaces-plugin-java8/build/build_python.sh
+++ b/codeready-workspaces-plugin-java8/build/build_python.sh
@@ -18,8 +18,8 @@ export PYTHON_IMAGE="registry.access.redhat.com/ubi8/python-38:1"
 
 usage () {
     echo "
-Usage:   $0 -v [CRW CSV_VERSION] -n [GITHUB_RELEASE_NAME]
-Example: $0 -v 2.y.0 -n plugin-java8-openj9
+Usage:   $0 -v [CRW CSV_VERSION] -n [ASSET_NAME]
+Example: $0 -v 2.y.0 -n java8-openj9
 "
     exit
 }

--- a/codeready-workspaces-plugin-java8/get-sources.sh
+++ b/codeready-workspaces-plugin-java8/get-sources.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -xe
-# script to get tarball(s) from Jenkins, plus additional dependencies as needed
+# script to get tarball(s) from GitHub Releases, plus additional dependencies as needed
 verbose=1
 scratchFlag=""
 JOB_BRANCH=""
@@ -59,7 +59,7 @@ if [[ ! ${JOB_BRANCH} ]]; then
 fi
 
 if [[ ${PULL_ASSETS} -eq 1 ]]; then
-	#### override any existing tarballs with newer ones from Jenkins build
+	#### override any existing tarballs with newer ones from asset build
 	log "[INFO] Download Assets:"
 	./uploadAssetsToGHRelease.sh --pull-assets -v "${CSV_VERSION}" -n ${ASSET_NAME}
 
@@ -84,7 +84,7 @@ if [[ ${PULL_ASSETS} -eq 1 ]]; then
 	log "[INFO] Upload new sources:${theTarGzs}"
 	rhpkg new-sources ${theTarGzs}
 	log "[INFO] Commit new sources from:${theTarGzs}"
-	COMMIT_MSG="Update from GitHub :: Maven ${MAVEN_VERSION} + ${ASSET_NAME} Assets ::${theTarGzs}"
+	COMMIT_MSG="chore: update from GH ${ASSET_NAME} assets :: ${theTarGzs}"
 	if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]] ;then 
 		log "[INFO] No new sources, so nothing to build."
 	elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then

--- a/codeready-workspaces-plugin-java8/get-sources.sh
+++ b/codeready-workspaces-plugin-java8/get-sources.sh
@@ -9,7 +9,6 @@ PULL_ASSETS=0
 DELETE_ASSETS=0
 PUBLISH_ASSETS=0
 generateDockerfileLABELs=1
-UPSTREAM_JOB_NAME="crw-deprecated_${JOB_BRANCH}" # eg., 2.4
 # maven - install 3.6 from https://maven.apache.org/download.cgi
 MAVEN_VERSION="3.6.3"
 LOMBOK_VERSION="1.18.18"
@@ -85,7 +84,7 @@ if [[ ${PULL_ASSETS} -eq 1 ]]; then
 	log "[INFO] Upload new sources:${theTarGzs}"
 	rhpkg new-sources ${theTarGzs}
 	log "[INFO] Commit new sources from:${theTarGzs}"
-	COMMIT_MSG="Update from GitHub :: Maven ${MAVEN_VERSION} + ${UPSTREAM_JOB_NAME} ::${theTarGzs}"
+	COMMIT_MSG="Update from GitHub :: Maven ${MAVEN_VERSION} + ${ASSET_NAME} Assets ::${theTarGzs}"
 	if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]] ;then 
 		log "[INFO] No new sources, so nothing to build."
 	elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then

--- a/codeready-workspaces-plugin-java8/get-sources.sh
+++ b/codeready-workspaces-plugin-java8/get-sources.sh
@@ -5,14 +5,25 @@ scratchFlag=""
 JOB_BRANCH=""
 doRhpkgContainerBuild=1
 forceBuild=0
-pullAssets=0
+PULL_ASSETS=0
+DELETE_ASSETS=0
+PUBLISH_ASSETS=0
 generateDockerfileLABELs=1
+UPSTREAM_JOB_NAME="crw-deprecated_${JOB_BRANCH}" # eg., 2.4
+# maven - install 3.6 from https://maven.apache.org/download.cgi
+MAVEN_VERSION="3.6.3"
+LOMBOK_VERSION="1.18.18"
+ASSET_NAME="java8"
+
 while [[ "$#" -gt 0 ]]; do
   case $1 in
 	'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
 	'-f'|'--force-build') forceBuild=1; shift 0;;
-	'-p'|'--pull-assets') pullAssets=1; shift 0;;
+	'-d'|'--delete-assets') DELETE_ASSETS=1; shift 0;;
+	'-a'|'--publish-assets') PUBLISH_ASSETS=1; shift 0;;
+	'-p'|'--pull-assets') PULL_ASSETS=1; shift 0;;
 	'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
+	'-v') CSV_VERSION="$2"; shift 1;;
 	*) JOB_BRANCH="$1"; shift 0;;
   esac
   shift 1
@@ -24,12 +35,23 @@ function log()
 	echo "$1"
   fi
 }
-function logn()
-{
-  if [[ ${verbose} -gt 0 ]]; then
-	echo -n "$1"
-  fi
-}
+
+if [[ ! -x ./uploadAssetsToGHRelease.sh ]]; then 
+    curl -sSLO "https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/${MIDSTM_BRANCH}/product/uploadAssetsToGHRelease.sh" && chmod +x uploadAssetsToGHRelease.sh
+fi
+
+if [[ ${DELETE_ASSETS} -eq 1 ]]; then
+	log "[INFO] Delete Previous GitHub Releases:"
+	./uploadAssetsToGHRelease.sh --delete-assets -v "${CSV_VERSION}" -n ${ASSET_NAME}
+	exit 0;
+fi
+
+if [[ ${PUBLISH_ASSETS} -eq 1 ]]; then
+	log "[INFO] Build Assets and Publish to GitHub Releases:"
+	./build/build.sh -v ${CSV_VERSION} -n ${ASSET_NAME}
+	exit 0;
+fi 
+
 
 # if not set, compute from current branch
 if [[ ! ${JOB_BRANCH} ]]; then 
@@ -37,145 +59,12 @@ if [[ ! ${JOB_BRANCH} ]]; then
 	if [[ ${JOB_BRANCH} == "2" ]]; then JOB_BRANCH="2.x"; fi
 fi
 
-UPSTREAM_JOB_NAME="crw-deprecated_${JOB_BRANCH}" # eg., 2.4
-
-jenkinsURL=""
-checkJenkinsURL() {
-	checkURL="$1"
-	if [[ ! $(curl -sSLI ${checkURL} 2>&1 | grep -E "404|Not Found|Failed to connect|No route to host|Could not resolve host|Connection refused") ]]; then
-		jenkinsURL="$checkURL"
-	else
-		jenkinsURL=""
-	fi
-}
-# try local env var first
-if [[ ${JENKINS_URL} ]]; then 
-	checkJenkinsURL "${JENKINS_URL}job/CRW_CI/job/${UPSTREAM_JOB_NAME}"
-fi
-# new jenkins & path
-if [[ ! $jenkinsURL ]]; then
-	checkJenkinsURL "https://main-jenkins-csb-crwqe.apps.ocp4.prod.psi.redhat.com/job/CRW_CI/job/${UPSTREAM_JOB_NAME}"
-fi
-# old jenkins & path
-if [[ ! $jenkinsURL ]]; then
-	checkJenkinsURL "https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/${UPSTREAM_JOB_NAME}"
-fi
-if [[ ! $jenkinsURL ]]; then
-	echo "[ERROR] Cannot resolve artifact(s) for this build. Must abort!"
-	exit 1
-fi
-theTarGzs="
-lastSuccessfulBuild/artifact/codeready-workspaces-deprecated/node10/target/codeready-workspaces-stacks-language-servers-dependencies-node10-x86_64.tar.gz
-lastSuccessfulBuild/artifact/codeready-workspaces-deprecated/python/target/codeready-workspaces-stacks-language-servers-dependencies-python-x86_64.tar.gz
-"
-lastSuccessfulURL="${jenkinsURL}/lastSuccessfulBuild/api/xml?xpath=/workflowRun/" # id
-# maven - install 3.6 from https://maven.apache.org/download.cgi
-MAVEN_VERSION="3.6.3"
-
-LOMBOK_VERSION="1.18.18"
-
-LABELs=""
-function addLabel () {
-	addLabeln "${1}" "${2}" "${3}"
-	echo ""
-}
-function addLabeln () {
-	LABEL_VAR=$1
-	if [[ "${2}" ]]; then LABEL_VAL=$2; else LABEL_VAL="${!LABEL_VAR}"; fi
-	if [[ "${3}" ]]; then PREFIX=$3; else PREFIX="  << "; fi
-	if [[ ${generateDockerfileLABELs} -eq 1 ]]; then 
-		LABELs="${LABELs} ${LABEL_VAR}=\"${LABEL_VAL}\""
-	fi
-	echo -n "${PREFIX}${LABEL_VAL}"
-}
-
-function parseCommitLog () 
-{
-	# Update from Jenkins ::
-	# crw_master ::
-	# Build #246 (2019-02-26 04:23:36 EST) ::
-	# che-ls-jdt @ 288b75765175d368480a688c8f3a77ce4758c72d (0.0.3) ::
-	# che @ f34f4c6c82de35081351e0b0686b1ae6589735d4 (6.19.0-SNAPSHOT) ::
-	# codeready-workspaces @ 184e24bee5bd923b733fa8c9f4b055a9caad40d2 (1.1.0.GA) ::
-	# codeready-workspaces-deprecated @ 620a53c5b0a1bbc02ba68e96be94ec3b932c9bee ::
-	# codeready-workspaces-assembly-main.tar.gz
-	# codeready-workspaces-stacks-language-servers-dependencies-bayesian.tar.gz
-	# codeready-workspaces-stacks-language-servers-dependencies-node.tar.gz
-	tarballs=""
-	OTHER=""
-	JOB_NAME=""
-	GHE="https://github.com/eclipse/"
-	GHR="https://github.com/redhat-developer/"
-	while [[ "$#" -gt 0 ]]; do
-	  case $1 in
-		'crw_master'|'crw_stable-branch'|'crw-deprecated_'*) JOB_NAME="$1"; shift 2;;
-		'Build'*) BUILD_NUMBER="$2"; BUILD_NUMBER=${BUILD_NUMBER#\#}; shift 6;; # trim # from the number, ignore timestamp
-		'che-dev'|'che-parent'|'che-lib'|'che-ls-jdt'|'che') 
-			sha="$3"; addLabeln "git.commit.eclipse__${1}" "${GHE}${1}/commit/${sha:0:7}"; addLabel "pom.version.eclipse__${1}" "${4:1:-1}" " "; shift 5;;
-		'codeready-workspaces')
-			sha="$3"; addLabeln "git.commit.redhat-developer__${1}" "${GHR}${1}/commit/${sha:0:7}"; addLabel "pom.version.redhat-developer__${1}" "${4:1:-1}" " "; shift 5;;
-		'codeready-workspaces-deprecated')
-			sha="$3"; addLabeln "git.commit.redhat-developer__${1}" "${GHR}${1}/commit/${sha:0:7}"; shift 4;;
-		*'tar.gz') tarballs="${tarballs} $1"; shift 1;;
-		*) OTHER="${OTHER} $1"; shift 1;; 
-	  esac
-	done
-	if [[ $JOB_NAME ]]; then
-		jenkinsServer="${jenkinsURL%/job/*}"
-		addLabel "jenkins.build.url" "${jenkinsServer}/view/CRW_CI/view/Pipelines/job/${JOB_NAME}/${BUILD_NUMBER}/"
-		for t in $tarballs; do
-			addLabel "jenkins.artifact.url" "${jenkinsServer}/view/CRW_CI/view/Pipelines/job/${JOB_NAME}/${BUILD_NUMBER}/artifact/**/${t}" "	 ++ "
-		done
-	else
-		addLabel "jenkins.tarball.url" "${jenkinsServer}/view/CRW_CI/view/Pipelines #${BUILD_NUMBER} /${tarballs}"
-	fi
-}
-
-function insertLabels () {
-	DOCKERFILE=$1
-	# trim off the footer of the file
-	mv ${DOCKERFILE} ${DOCKERFILE}.bak
-	sed '/.*insert generated LABELs below this line.*/q' ${DOCKERFILE}.bak > ${DOCKERFILE}
-	# insert marker
-	if [[ ! $(cat ${DOCKERFILE}.bak | grep "insert generated LABELs below this line") ]]; then 
-		echo "" >> ${DOCKERFILE}
-		echo "" >> ${DOCKERFILE}
-		echo "# insert generated LABELs below this line" >> ${DOCKERFILE}
-	fi
-	# add new labels
-	echo "LABEL \\" >> ${DOCKERFILE}
-	for l in $LABELs; do
-		echo "	  ${l} \\" >> ${DOCKERFILE}
-	done
-	echo "	  jenkins.build.number=\"${BUILD_NUMBER}\"" >> ${DOCKERFILE}
-	rm -f ${DOCKERFILE}.bak
-}
-
-function getFingerprints ()
-{
-	outputFile=$1
-	latestFingerprint="$(curl -L ${jenkinsURL}/lastSuccessfulBuild/fingerprints/ 2>&1 | grep ${outputFile} | sed -e "s#.\+/fingerprint/\([0-9a-f]\+\)/\".\+#\1#")"
-	currentFingerprint="$(cat sources | grep ${outputFile} | sed -e "s#\([0-9a-f]\+\) .\+#\1#")"
-}
-
-# get the public URL for the tarball(s)
-outputFiles=""
-
 #### override any existing tarballs with newer ones from Jenkins build
-for theTarGz in ${theTarGzs}; do
-	outputFile=${theTarGz##*/}
-	log "[INFO] Download ${jenkinsURL}/${theTarGz}:"
-	rm -f ${outputFile}
-	getFingerprints ${outputFile}
-	if [[ ! ${latestFingerprint} ]]; then 
-		echo "[WARNING] Cannot resolve artifact fingerprints for ${outputFile}"
-	fi
-	
-	if [[ "${latestFingerprint}" != "${currentFingerprint}" ]] || [[ ! -f ${outputFile} ]] || [[ ${pullAssets} -eq 1 ]]; then 
-		curl -L -o ${outputFile} ${jenkinsURL}/${theTarGz}
-		outputFiles="${outputFiles} ${outputFile}"
-	fi
-done
+log "[INFO] Download Assets:"
+./uploadAssetsToGHRelease.sh --pull-assets -v "${CSV_VERSION}" -n ${ASSET_NAME}
+
+#get names of the downloaded tarballs
+theTarGzs="$(ls *.tar.gz)"
 
 # update Dockerfile to record version we expect for MAVEN_VERSION
 sed Dockerfile \
@@ -184,60 +73,50 @@ sed Dockerfile \
 	> Dockerfile.2
 
 # pull maven (if not present, or forced, or new version in dockerfile)
-if [[ ! -f apache-maven-${MAVEN_VERSION}-bin.tar.gz ]] || [[ $(diff -U 0 --suppress-common-lines -b Dockerfile.2 Dockerfile) ]] || [[ ${pullAssets} -eq 1 ]]; then
+if [[ ! -f apache-maven-${MAVEN_VERSION}-bin.tar.gz ]] || [[ $(diff -U 0 --suppress-common-lines -b Dockerfile.2 Dockerfile) ]] || [[ ${PULL_ASSETS} -eq 1 ]]; then
 	mv -f Dockerfile.2 Dockerfile
 	curl -sSL -O http://mirror.csclub.uwaterloo.ca/apache/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
 	curl -sSL -O https://projectlombok.org/downloads/lombok-${LOMBOK_VERSION}.jar
 fi
-outputFiles="apache-maven-${MAVEN_VERSION}-bin.tar.gz lombok-${LOMBOK_VERSION}.jar ${outputFiles}"
+outputFiles="apache-maven-${MAVEN_VERSION}-bin.tar.gz lombok-${LOMBOK_VERSION}.jar ${theTarGzs}"
 
-if [[ ${outputFiles} ]]; then
-	log "[INFO] Upload new sources:${outputFiles}"
-	rhpkg new-sources ${outputFiles}
-	log "[INFO] Commit new sources from:${outputFiles}"
-	field=id; ID=$(curl -L -s -S ${lastSuccessfulURL}${field} | sed -e "s#<${field}>\(.\+\)</${field}>#\1#" -e "s#&lt;br/&gt; #\n#g" -e "s#\&lt;a.\+/a\&gt;##g")
-	if [[ $(echo $ID | grep -E "404 Not Found|ERROR 404|Application is not available") ]]; then 
-		echo $ID
-		echo "[ERROR] Problem loading ID from ${lastSuccessfulURL}${field} :: NOT FOUND!"
-		exit 1;
-	fi
-	COMMIT_MSG="Update from Jenkins :: Maven ${MAVEN_VERSION} + ${UPSTREAM_JOB_NAME} :: ${ID}
-::${outputFiles}"
-	parseCommitLog ${COMMIT_MSG}
-	insertLabels Dockerfile
-	if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]] ;then 
-		log "[INFO] No new sources, so nothing to build."
-	elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
-		log "[INFO] Push change:"
-		git pull; git push; git status -s || true
-	fi
-	if [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
-		echo "[INFO] #1 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
-		git status || true
-		tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
-		taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
-		ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
-		if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
+
+log "[INFO] Upload new sources:${theTarGzs}"
+rhpkg new-sources ${theTarGzs}
+log "[INFO] Commit new sources from:${theTarGzs}"
+COMMIT_MSG="Update from GitHub :: Maven ${MAVEN_VERSION} + ${UPSTREAM_JOB_NAME} ::${theTarGzs}"
+if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]] ;then 
+	log "[INFO] No new sources, so nothing to build."
+elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
+	log "[INFO] Push change:"
+	git pull; git push; git status -s || true
+fi
+if [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
+	echo "[INFO] #1 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
+	git status || true
+	tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
+	taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
+	ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
+	if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
 
 $ERRORS
 
 "; exit 1; fi
-	fi
+fi
+
+if [[ ${forceBuild} -eq 1 ]]; then
+	echo "[INFO] #2 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
+	git status || true
+	tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
+	taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
+	ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
+	if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
+
+$ERRORS
+
+"; exit 1; fi
 else
-	if [[ ${forceBuild} -eq 1 ]]; then
-		echo "[INFO] #2 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
-		git status || true
-		tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
-		taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
-		ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
-		if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
-
-$ERRORS
-
-"; exit 1; fi
-	else
-		log "[INFO] No new sources, so nothing to build."
-	fi
+	log "[INFO] No new sources, so nothing to build."
 fi
 
 # cleanup

--- a/codeready-workspaces-plugin-java8/get-sources.sh
+++ b/codeready-workspaces-plugin-java8/get-sources.sh
@@ -91,35 +91,34 @@ if [[ ${PULL_ASSETS} -eq 1 ]]; then
 		log "[INFO] Push change:"
 		git pull; git push; git status -s || true
 	fi
-fi
-
-if [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
-	echo "[INFO] #1 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
-	git status || true
-	tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
-	taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
-	ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
-	if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
+	if [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
+		echo "[INFO] #1 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
+		git status || true
+		tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
+		taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
+		ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
+		if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
 
 $ERRORS
 
 "; exit 1; fi
-fi
-
-if [[ ${forceBuild} -eq 1 ]]; then
-	echo "[INFO] #2 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
-	git status || true
-	tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
-	taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
-	ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
-	if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
-
-$ERRORS
-
-"; exit 1; fi
+	fi
 else
-	log "[INFO] No new sources, so nothing to build."
-fi
+	if [[ ${forceBuild} -eq 1 ]]; then
+		echo "[INFO] #2 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
+		git status || true
+		tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
+		taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
+		ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
+		if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
+
+$ERRORS
+
+"; exit 1; fi
+	else
+		log "[INFO] No new sources, so nothing to build."
+	fi
+fi 
 
 # cleanup
 rm -fr Dockerfile.2

--- a/codeready-workspaces-plugin-kubernetes/build/build.sh
+++ b/codeready-workspaces-plugin-kubernetes/build/build.sh
@@ -19,8 +19,8 @@ export GOLANG_IMAGE="registry.access.redhat.com/ubi8/go-toolset:1.14.7-15"
 
 usage () {
     echo "
-Usage:   $0 -v [CRW CSV_VERSION] -n [GITHUB_RELEASE_NAME]
-Example: $0 -v 2.y.0 -n plugin-kubernetes
+Usage:   $0 -v [CRW CSV_VERSION] -n [ASSET_NAME]
+Example: $0 -v 2.y.0 -n kubernetes
 "
     exit
 }

--- a/codeready-workspaces-plugin-kubernetes/build/build.sh
+++ b/codeready-workspaces-plugin-kubernetes/build/build.sh
@@ -1,0 +1,77 @@
+#!/bin/bash -xe
+
+# Copyright (c) 2018-2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+# shellcheck disable=SC2155
+export SCRIPT_DIR=$(cd "$(dirname "$0")" || exit; pwd)
+
+export KAMEL_VERSION="1.5.0"
+export GOLANG_IMAGE="registry.access.redhat.com/ubi8/go-toolset:1.14.7-15"
+
+usage () {
+    echo "
+Usage:   $0 -v [CRW CSV_VERSION] -n [GITHUB_RELEASE_NAME]
+Example: $0 -v 2.y.0 -n plugin-kubernetes
+"
+    exit
+}
+
+if [[ $# -lt 1 ]]; then usage; fi
+
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    '-v') CSV_VERSION="$2"; shift 1;;
+    '-n') ASSET_NAME="$2"; shift 1;;
+    '--help'|'-h') usage;;
+  esac
+  shift 1
+done
+
+cd "${SCRIPT_DIR}"
+[[ -e target ]] && rm -Rf target
+
+echo ""
+echo "CodeReady Workspaces :: Kamel"
+echo ""
+
+mkdir -p target/kamel
+
+PODMAN=$(command -v podman || true)
+if [[ ! -x $PODMAN ]]; then
+  echo "[WARNING] podman is not installed."
+ PODMAN=$(command -v docker || true)
+  if [[ ! -x $PODMAN ]]; then
+    echo "[ERROR] docker is not installed. Aborting."; exit 1
+  fi
+fi
+
+ARCH="$(uname -m)"
+if [[ ! ${WORKSPACE} ]]; then WORKSPACE=/tmp; fi
+tarball="${WORKSPACE}/kamel-${KAMEL_VERSION}-${ARCH}.tar.gz"
+
+${PODMAN} run --rm -v "${SCRIPT_DIR}"/target/kamel:/kamel -u root ${GOLANG_IMAGE} sh -c "
+    cd /tmp
+    curl -sSLo- https://github.com/apache/camel-k/archive/v${KAMEL_VERSION}.tar.gz | tar xz || true
+    ls -1 camel*
+    cd camel-k-${KAMEL_VERSION}
+    make build-kamel
+    cp  /tmp/camel-k-${KAMEL_VERSION}/kamel /kamel/kamel
+    "
+tar -czf "${tarball}" -C target/kamel .
+
+# upload the binary to GH
+if [[ ! -x ./uploadAssetsToGHRelease.sh ]]; then 
+    curl -sSLO "https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/${MIDSTM_BRANCH}/product/uploadAssetsToGHRelease.sh" && chmod +x uploadAssetsToGHRelease.sh
+fi
+./uploadAssetsToGHRelease.sh --publish-assets -v "${CSV_VERSION}" -b "${MIDSTM_BRANCH}" -n ${ASSET_NAME} "${tarball}"
+
+${PODMAN} rmi -f ${GOLANG_IMAGE}

--- a/codeready-workspaces-plugin-kubernetes/get-sources.sh
+++ b/codeready-workspaces-plugin-kubernetes/get-sources.sh
@@ -52,8 +52,6 @@ if [[ ! ${JOB_BRANCH} ]]; then
 	if [[ ${JOB_BRANCH} == "2" ]]; then JOB_BRANCH="2.x"; fi
 fi
 
-UPSTREAM_JOB_NAME="crw-deprecated_${JOB_BRANCH}" # eg., 2.6
-
 # see https://github.com/redhat-developer/codeready-workspaces-deprecated/blob/crw-2-rhel-8/kamel/build.sh#L16 or https://github.com/apache/camel-k/releases
 KAMEL_BUILDSH="https://github.com/redhat-developer/codeready-workspaces-deprecated/raw/$(git rev-parse --abbrev-ref HEAD)/kamel/build.sh"
 KAMEL_VERSION="$(curl -sSLo- ${KAMEL_BUILDSH} | grep "export KAMEL_VERSION" | sed -r -e 's#.+KAMEL_VERSION="(.+)"#\1#')"

--- a/codeready-workspaces-plugin-kubernetes/get-sources.sh
+++ b/codeready-workspaces-plugin-kubernetes/get-sources.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -xe
-# script to get tarball(s) from Jenkins
+# script to get tarball(s) from GitHub Releases
 scratchFlag=""
 JOB_BRANCH=""
 doRhpkgContainerBuild=1
@@ -90,8 +90,7 @@ if [[ ${outputFiles} ]]; then
 	log "[INFO] Upload new sources: ${outputFiles}"
 	rhpkg new-sources ${outputFiles}
 	log "[INFO] Commit new sources from: ${outputFiles}"
-	COMMIT_MSG="Update from GitHub :: kamel ${KAMEL_VERSION} from ${ASSET_NAME} Assets 
-:: ${outputFiles}"
+	COMMIT_MSG="chore: update from GH ${ASSET_NAME} assets :: ${theTarGzs}"
 	if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]] ;then 
 		log "[INFO] No new sources, so nothing to build."
 	elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then

--- a/codeready-workspaces-plugin-kubernetes/get-sources.sh
+++ b/codeready-workspaces-plugin-kubernetes/get-sources.sh
@@ -90,7 +90,7 @@ if [[ ${outputFiles} ]]; then
 	log "[INFO] Upload new sources: ${outputFiles}"
 	rhpkg new-sources ${outputFiles}
 	log "[INFO] Commit new sources from: ${outputFiles}"
-	COMMIT_MSG="Update from GitHub :: kamel ${KAMEL_VERSION} from ${UPSTREAM_JOB_NAME}
+	COMMIT_MSG="Update from GitHub :: kamel ${KAMEL_VERSION} from ${ASSET_NAME} Assets 
 :: ${outputFiles}"
 	if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]] ;then 
 		log "[INFO] No new sources, so nothing to build."

--- a/codeready-workspaces-plugin-kubernetes/get-sources.sh
+++ b/codeready-workspaces-plugin-kubernetes/get-sources.sh
@@ -4,13 +4,20 @@ scratchFlag=""
 JOB_BRANCH=""
 doRhpkgContainerBuild=1
 forceBuild=0
-pullAssets=0
+PULL_ASSETS=0
+DELETE_ASSETS=0
+PUBLISH_ASSETS=0
+ASSET_NAME="kubernetes"
+
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
 	'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
 	'-f'|'--force-build') forceBuild=1; shift 0;;
-	'-p'|'--pull-assets') pullAssets=1; shift 0;;
+	'-d'|'--delete-assets') DELETE_ASSETS=1; shift 0;;
+	'-a'|'--publish-assets') PUBLISH_ASSETS=1; shift 0;;
+	'-p'|'--pull-assets') PULL_ASSETS=1; shift 0;;
 	'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
+	'-v') CSV_VERSION="$2"; shift 1;;
 	*) JOB_BRANCH="$1"; shift 0;;
 	esac
 	shift 1
@@ -22,6 +29,22 @@ function log()
 		echo "$1"
 	fi
 }
+
+if [[ ! -x ./uploadAssetsToGHRelease.sh ]]; then 
+    curl -sSLO "https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/${MIDSTM_BRANCH}/product/uploadAssetsToGHRelease.sh" && chmod +x uploadAssetsToGHRelease.sh
+fi
+
+if [[ ${DELETE_ASSETS} -eq 1 ]]; then
+	log "[INFO] Delete Previous GitHub Releases:"
+	./uploadAssetsToGHRelease.sh --delete-assets -v "${CSV_VERSION}" -n ${ASSET_NAME}
+	exit 0;
+fi
+
+if [[ ${PUBLISH_ASSETS} -eq 1 ]]; then
+	log "[INFO] Build Assets and Publish to GitHub Releases:"
+	./build/build.sh -v ${CSV_VERSION} -n ${ASSET_NAME}
+	exit 0;
+fi 
 
 # if not set, compute from current branch
 if [[ ! ${JOB_BRANCH} ]]; then 
@@ -36,68 +59,40 @@ KAMEL_BUILDSH="https://github.com/redhat-developer/codeready-workspaces-deprecat
 KAMEL_VERSION="$(curl -sSLo- ${KAMEL_BUILDSH} | grep "export KAMEL_VERSION" | sed -r -e 's#.+KAMEL_VERSION="(.+)"#\1#')"
 echo "Using KAMEL_VERSION = ${KAMEL_VERSION} from ${KAMEL_BUILDSH}"
 
-jenkinsURL=""
-checkJenkinsURL() {
-	checkURL="$1"
-	if [[ ! $(curl -sSLI ${checkURL} 2>&1 | grep -E "404|Not Found|Failed to connect|No route to host|Could not resolve host|Connection refused") ]]; then
-		jenkinsURL="$checkURL"
-	else
-		jenkinsURL=""
-	fi
-}
-# try local env var first
-if [[ ${JENKINS_URL} ]]; then 
-	checkJenkinsURL "${JENKINS_URL}job/CRW_CI/job/${UPSTREAM_JOB_NAME}"
-fi
-# new jenkins & path
-if [[ ! $jenkinsURL ]]; then
-	checkJenkinsURL "https://main-jenkins-csb-crwqe.apps.ocp4.prod.psi.redhat.com/job/CRW_CI/job/${UPSTREAM_JOB_NAME}"
-fi
-# old jenkins & path
-if [[ ! $jenkinsURL ]]; then
-	checkJenkinsURL "https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/${UPSTREAM_JOB_NAME}"
-fi
-if [[ ! $jenkinsURL ]]; then
-	echo "[ERROR] Cannot resolve artifact(s) for this build. Must abort!"
-	exit 1
-fi
-lastSuccessfulURL="${jenkinsURL}/lastSuccessfulBuild/api/xml?xpath=/workflowRun/" # id
-
-jenkinsURL=${jenkinsURL}/lastSuccessfulBuild/artifact/codeready-workspaces-deprecated/kamel/target
 
 # patch Dockerfile to record versions we expect
 sed Dockerfile \
 		-e "s#KAMEL_VERSION=\"\([^\"]\+\)\"#KAMEL_VERSION=\"${KAMEL_VERSION}\"#" \
 		> Dockerfile.2
 
-if [[ $(diff -U 0 --suppress-common-lines -b Dockerfile Dockerfile.2) ]] || [[ ${pullAssets} -eq 1 ]]; then
+
+if [[ $(diff -U 0 --suppress-common-lines -b Dockerfile Dockerfile.2) ]] || [[ ${PULL_ASSETS} -eq 1 ]]; then
 	rm -fr asset-*
 	mv -f Dockerfile.2 Dockerfile
+
+
+	log "[INFO] Download Assets:"
+	./uploadAssetsToGHRelease.sh --fetch-assets -v "${CSV_VERSION}" -n ${ASSET_NAME}
+	
 	# x86
-	curl -sSLo - ${jenkinsURL}/kamel-${KAMEL_VERSION}-x86_64.tar.gz | tar -xz && mv kamel asset-x86_64-kamel
+	./kamel-${KAMEL_VERSION}-x86_64.tar.gz | tar -xz && mv kamel asset-x86_64-kamel
 
 	# s390x
-	curl -sSLo - ${jenkinsURL}/kamel-${KAMEL_VERSION}-s390x.tar.gz | tar -xz && mv kamel asset-s390x-kamel
+	./kamel-${KAMEL_VERSION}-s390x.tar.gz | tar -xz && mv kamel asset-s390x-kamel
 
 	# ppc64le
-	curl -sSLo - ${jenkinsURL}/kamel-${KAMEL_VERSION}-ppc64le.tar.gz | tar -xz && mv kamel asset-ppc64le-kamel
+	./kamel-${KAMEL_VERSION}-ppc64le.tar.gz | tar -xz && mv kamel asset-ppc64le-kamel
 	
 	for d in asset-*; do echo "[INFO] Pack ${d}.tar.gz"; mv ${d} ${d##*-}; tar -cvzf ${d}.tar.gz ${d##*-}; mv ${d##*-} ${d}-unpacked; done
 	rm -fr asset-*-unpacked
 fi
 
-outputFiles="$(ls asset-*.tar.gz || true)"
+outputFiles="$(ls *.tar.gz || true)"
 if [[ ${outputFiles} ]]; then
 	log "[INFO] Upload new sources: ${outputFiles}"
 	rhpkg new-sources ${outputFiles}
 	log "[INFO] Commit new sources from: ${outputFiles}"
-	field=id; ID=$(curl -L -s -S ${lastSuccessfulURL}${field} | sed -e "s#<${field}>\(.\+\)</${field}>#\1#" -e "s#&lt;br/&gt; #\n#g" -e "s#\&lt;a.\+/a\&gt;##g")
-	if [[ $(echo $ID | grep -E "404 Not Found|ERROR 404|Application is not available") ]]; then 
-		echo $ID
-		echo "[ERROR] Problem loading ID from ${lastSuccessfulURL}${field} :: NOT FOUND!"
-		exit 1;
-	fi
-	COMMIT_MSG="Update from Jenkins :: kamel ${KAMEL_VERSION} from ${UPSTREAM_JOB_NAME} :: ${ID}
+	COMMIT_MSG="Update from GitHub :: kamel ${KAMEL_VERSION} from ${UPSTREAM_JOB_NAME}
 :: ${outputFiles}"
 	if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]] ;then 
 		log "[INFO] No new sources, so nothing to build."

--- a/codeready-workspaces-plugin-openshift/get-sources.sh
+++ b/codeready-workspaces-plugin-openshift/get-sources.sh
@@ -4,12 +4,12 @@
 scratchFlag=""
 doRhpkgContainerBuild=1
 forceBuild=0
-pullAssets=0
+PULL_ASSETS=0
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
 	'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
 	'-f'|'--force-build') forceBuild=1; shift 0;;
-	'-p'|'--pull-assets') pullAssets=1; shift 0;;
+	'-p'|'--pull-assets') PULL_ASSETS=1; shift 0;;
 	'-a'|'--publish-assets') exit 0; shift 0;;
 	'-d'|'--delete-assets') exit 0; shift 0;;
 	'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
@@ -39,7 +39,7 @@ sed Dockerfile \
 		-e "s#ODO_VERSION=\"\([^\"]\+\)\"#ODO_VERSION=\"${ODO_VERSION}\"#" \
 		> Dockerfile.2
 
-if [[ $(diff -U 0 --suppress-common-lines -b Dockerfile.2 Dockerfile) ]] || [[ ${pullAssets} -eq 1 ]]; then
+if [[ $(diff -U 0 --suppress-common-lines -b Dockerfile.2 Dockerfile) ]] || [[ ${PULL_ASSETS} -eq 1 ]]; then
 	mv -f Dockerfile.2 Dockerfile
 	mkdir -p x86_64 s390x ppc64le
 	curl -sSLo x86_64/odo https://mirror.openshift.com/pub/openshift-v4/clients/odo/${ODO_VERSION}/odo-linux-amd64 && chmod +x x86_64/odo

--- a/codeready-workspaces-plugin-openshift/get-sources.sh
+++ b/codeready-workspaces-plugin-openshift/get-sources.sh
@@ -10,7 +10,10 @@ while [[ "$#" -gt 0 ]]; do
 	'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
 	'-f'|'--force-build') forceBuild=1; shift 0;;
 	'-p'|'--pull-assets') pullAssets=1; shift 0;;
+	'-a'|'--publish-assets') exit 0; shift 0;;
+	'-d'|'--delete-assets') exit 0; shift 0;;
 	'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
+	'-v') CSV_VERSION="$2"; shift 1;;
 	esac
 	shift 1
 done

--- a/codeready-workspaces-pluginbroker-artifacts/get-sources.sh
+++ b/codeready-workspaces-pluginbroker-artifacts/get-sources.sh
@@ -11,7 +11,10 @@ while [[ "$#" -gt 0 ]]; do
 	case $1 in
 		'-n'|'--nobuild') exit 0; shift 0;;
 		'-p'|'--pull-assets') pullAssets=1; shift 0;;
+		'-a'|'--publish-assets') exit 0; shift 0;;
+		'-d'|'--delete-assets') exit 0; shift 0;;
 		'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
+		'-v') CSV_VERSION="$2"; shift 1;;
 	esac
 	shift 1
 done

--- a/codeready-workspaces-pluginbroker-artifacts/get-sources.sh
+++ b/codeready-workspaces-pluginbroker-artifacts/get-sources.sh
@@ -2,15 +2,15 @@
 # script to trigger rhpkg - no sources needed here
 
 scratchFlag=""
-# NOTE: pullAssets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
+# NOTE: --pull-assets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
 # here we want to collect assets during sync-to-downsteam (using get-sources.sh -n -p)
 # so that rhpkg build is simply a brew wrapper (using get-sources.sh -f)
-pullAssets=0
+PULL_ASSETS=0
 
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
 		'-n'|'--nobuild') exit 0; shift 0;;
-		'-p'|'--pull-assets') pullAssets=1; shift 0;;
+		'-p'|'--pull-assets') PULL_ASSETS=1; shift 0;;
 		'-a'|'--publish-assets') exit 0; shift 0;;
 		'-d'|'--delete-assets') exit 0; shift 0;;
 		'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;

--- a/codeready-workspaces-pluginbroker-metadata/get-sources.sh
+++ b/codeready-workspaces-pluginbroker-metadata/get-sources.sh
@@ -11,7 +11,10 @@ while [[ "$#" -gt 0 ]]; do
 	case $1 in
 		'-n'|'--nobuild') exit 0; shift 0;;
 		'-p'|'--pull-assets') pullAssets=1; shift 0;;
+		'-a'|'--publish-assets') exit 0; shift 0;;
+		'-d'|'--delete-assets') exit 0; shift 0;;
 		'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
+		'-v') CSV_VERSION="$2"; shift 1;;
 	esac
 	shift 1
 done

--- a/codeready-workspaces-pluginbroker-metadata/get-sources.sh
+++ b/codeready-workspaces-pluginbroker-metadata/get-sources.sh
@@ -2,15 +2,15 @@
 # script to trigger rhpkg - no sources needed here
 
 scratchFlag=""
-# NOTE: pullAssets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
+# NOTE: --pull-assets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
 # here we want to collect assets during sync-to-downsteam (using get-sources.sh -n -p)
 # so that rhpkg build is simply a brew wrapper (using get-sources.sh -f)
-pullAssets=0
+PULL_ASSETS=0
 
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
 		'-n'|'--nobuild') exit 0; shift 0;;
-		'-p'|'--pull-assets') pullAssets=1; shift 0;;
+		'-p'|'--pull-assets') PULL_ASSETS=1; shift 0;;
 		'-a'|'--publish-assets') exit 0; shift 0;;
 		'-d'|'--delete-assets') exit 0; shift 0;;
 		'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;

--- a/codeready-workspaces-pluginregistry/get-sources.sh
+++ b/codeready-workspaces-pluginregistry/get-sources.sh
@@ -4,16 +4,16 @@ verbose=0
 scratchFlag=""
 doRhpkgContainerBuild=1
 forceBuild=0
-# NOTE: pullAssets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
+# NOTE: --pull-assets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
 # here we want to collect assets during sync-to-downsteam (using get-sources.sh -n -p)
 # so that rhpkg build is simply a brew wrapper (using get-sources.sh -f)
-pullAssets=0
+PULL_ASSETS=0
 
 tmpContainer=pluginregistry:tmp
 
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
-		'-p'|'--pull-assets') pullAssets=1; shift 0;;
+		'-p'|'--pull-assets') PULL_ASSETS=1; shift 0;;
 		'-a'|'--publish-assets') exit 0; shift 0;;
 		'-d'|'--delete-assets') exit 0; shift 0;;
 		'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
@@ -31,7 +31,7 @@ function log()
 	fi
 }
 
-if [[ ${pullAssets} -eq 1 ]]; then 
+if [[ ${PULL_ASSETS} -eq 1 ]]; then 
 	BUILDER=$(command -v podman || true)
 	if [[ ! -x $BUILDER ]]; then
 		# echo "[WARNING] podman is not installed, trying with docker"
@@ -97,7 +97,7 @@ if [[ ${pullAssets} -eq 1 ]]; then
 fi
 
 # update tarballs - step 4 - commit changes if diff different
-if [[ ${TAR_DIFF} ]] || [[ ${TAR_DIFF2} ]] || [[ ${pullAssets} -eq 1 ]]; then
+if [[ ${TAR_DIFF} ]] || [[ ${TAR_DIFF2} ]] || [[ ${PULL_ASSETS} -eq 1 ]]; then
 	log "[INFO] Commit new sources"
 	rhpkg new-sources ${TARGZs}
 	COMMIT_MSG="Update ${TARGZs}"

--- a/codeready-workspaces-pluginregistry/get-sources.sh
+++ b/codeready-workspaces-pluginregistry/get-sources.sh
@@ -14,9 +14,12 @@ tmpContainer=pluginregistry:tmp
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
 		'-p'|'--pull-assets') pullAssets=1; shift 0;;
+		'-a'|'--publish-assets') exit 0; shift 0;;
+		'-d'|'--delete-assets') exit 0; shift 0;;
 		'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
 		'-f'|'--force-build') forceBuild=1; shift 0;;
 		'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
+		'-v') CSV_VERSION="$2"; shift 1;;
 	esac
 	shift 1
 done

--- a/codeready-workspaces-stacks-cpp/get-sources.sh
+++ b/codeready-workspaces-stacks-cpp/get-sources.sh
@@ -5,9 +5,12 @@ scratchFlag=""
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
 	'-p'|'--pull-assets') shift 0;;
+	'-a'|'--publish-assets') exit 0; shift 0;;
+	'-d'|'--delete-assets') exit 0; shift 0;;
 	'-n'|'--nobuild') exit 0; shift 0;;
 	'-f'|'--force-build') forceBuild=1; shift 0;;
 	'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
+	'-v') CSV_VERSION="$2"; shift 1;;
 	esac
 	shift 1
 done

--- a/codeready-workspaces-stacks-cpp/get-sources.sh
+++ b/codeready-workspaces-stacks-cpp/get-sources.sh
@@ -1,10 +1,11 @@
 #!/bin/bash -xe
 # script to trigger rhpkg - no sources needed here
+PULL_ASSETS=0
 
 scratchFlag=""
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
-	'-p'|'--pull-assets') shift 0;;
+	'-p'|'--pull-assets') PULL_ASSETS=1; shift 0;;
 	'-a'|'--publish-assets') exit 0; shift 0;;
 	'-d'|'--delete-assets') exit 0; shift 0;;
 	'-n'|'--nobuild') exit 0; shift 0;;

--- a/codeready-workspaces-stacks-dotnet/get-sources.sh
+++ b/codeready-workspaces-stacks-dotnet/get-sources.sh
@@ -5,9 +5,12 @@ scratchFlag=""
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
 	'-p'|'--pull-assets') shift 0;;
+	'-a'|'--publish-assets') exit 0; shift 0;;
+	'-d'|'--delete-assets') exit 0; shift 0;;
 	'-n'|'--nobuild') exit 0; shift 0;;
 	'-f'|'--force-build') forceBuild=1; shift 0;;
 	'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
+	'-v') CSV_VERSION="$2"; shift 1;;
 	esac
 	shift 1
 done

--- a/codeready-workspaces-stacks-dotnet/get-sources.sh
+++ b/codeready-workspaces-stacks-dotnet/get-sources.sh
@@ -1,10 +1,11 @@
 #!/bin/bash -xe
 # script to trigger rhpkg - no sources needed here
+PULL_ASSETS=0
 
 scratchFlag=""
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
-	'-p'|'--pull-assets') shift 0;;
+	'-p'|'--pull-assets') PULL_ASSETS=1; shift 0;;
 	'-a'|'--publish-assets') exit 0; shift 0;;
 	'-d'|'--delete-assets') exit 0; shift 0;;
 	'-n'|'--nobuild') exit 0; shift 0;;

--- a/codeready-workspaces-stacks-golang/build/build.sh
+++ b/codeready-workspaces-stacks-golang/build/build.sh
@@ -20,8 +20,8 @@ export GOLANG_LS_VERSION="0.1.7"
 
 usage () {
     echo "
-Usage:   $0 -v [CRW CSV_VERSION] -n [GITHUB_RELEASE_NAME]
-Example: $0 -v 2.y.0 -n stacks-golang
+Usage:   $0 -v [CRW CSV_VERSION] -n [ASSET_NAME]
+Example: $0 -v 2.y.0 -n golang
 "
     exit
 }

--- a/codeready-workspaces-stacks-golang/build/build.sh
+++ b/codeready-workspaces-stacks-golang/build/build.sh
@@ -1,0 +1,98 @@
+#!/bin/bash -xe
+
+# Copyright (c) 2018-2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+# shellcheck disable=SC2155
+export SCRIPT_DIR=$(cd "$(dirname "$0")" || exit; pwd)
+export GOLANG_IMAGE="registry.access.redhat.com/ubi8/go-toolset:1.15.14-3"
+export GOLANG_LINT_VERSION="v1.22.2"
+export GOLANG_LS_OLD_DEPS="console-stamp@0.2.9 strip-ansi@5.2.0 has-ansi@4.0.0 ansi-regex@4.1.0 chalk@2.4.2 escape-string-regexp@2.0.0 ansi-styles@4.1.0 supports-color@7.0.0"
+export GOLANG_LS_VERSION="0.1.7"
+
+usage () {
+    echo "
+Usage:   $0 -v [CRW CSV_VERSION] -n [GITHUB_RELEASE_NAME]
+Example: $0 -v 2.y.0 -n stacks-golang
+"
+    exit
+}
+
+if [[ $# -lt 1 ]]; then usage; fi
+
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    '-v') CSV_VERSION="$2"; shift 1;;
+    '-n') ASSET_NAME="$2"; shift 1;;
+    '--help'|'-h') usage;;
+  esac
+  shift 1
+done
+
+cd "${SCRIPT_DIR}"
+[[ -e target ]] && rm -Rf target
+
+echo ""
+echo "CodeReady Workspaces :: Stacks :: Language Servers :: Golang Dependencies"
+echo ""
+
+mkdir -p target/go
+
+PODMAN=$(command -v podman || true)
+if [[ ! -x $PODMAN ]]; then
+  echo "[WARNING] podman is not installed."
+ PODMAN=$(command -v docker || true)
+  if [[ ! -x $PODMAN ]]; then
+    echo "[ERROR] docker is not installed. Aborting."; exit 1
+  fi
+fi
+
+ARCH="$(uname -m)"
+if [[ ! ${WORKSPACE} ]]; then WORKSPACE=/tmp; fi
+tarball="${WORKSPACE}/codeready-workspaces-stacks-language-servers-dependencies-${ASSET_NAME}-${ARCH}.tar.gz"
+
+# go get LS go deps
+${PODMAN} run --rm -v "${SCRIPT_DIR}"/target/go:/opt/app-root/src/go -u root ${GOLANG_IMAGE} sh -c "
+    go get -v github.com/stamblerre/gocode;
+    go get -v github.com/uudashr/gopkgs/cmd/gopkgs;
+    go get -v github.com/ramya-rao-a/go-outline;
+    go get -v github.com/acroca/go-symbols;
+    go get -v golang.org/x/tools/cmd/guru;
+    go get -v golang.org/x/tools/cmd/gorename;
+    go get -v github.com/fatih/gomodifytags;
+    go get -v github.com/haya14busa/goplay/cmd/goplay;
+    go get -v github.com/josharian/impl;
+    go get -v golang.org/x/tools/cmd/gotype;
+    go get -v github.com/rogpeppe/godef;
+    go get -v golang.org/x/tools/cmd/godoc;
+    go get -v github.com/zmb3/gogetdoc;
+    go get -v golang.org/x/tools/cmd/goimports;
+    go get -v sourcegraph.com/sqs/goreturns;
+    go get -v golang.org/x/lint/golint;
+    go get -v github.com/cweill/gotests/...;
+    go get -v honnef.co/go/tools/...;
+    go get -v github.com/sourcegraph/go-langserver;
+    go get -v github.com/go-delve/delve/cmd/dlv;
+    go get -v github.com/davidrjenni/reftools/cmd/fillstruct;
+    go get -v golang.org/x/tools/gopls;
+    go build -o /go/bin/gocode-gomod github.com/stamblerre/gocode;
+    wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s ${GOLANG_LINT_VERSION}
+    chmod -R 777 /go
+    "
+tar -czf "${tarball}" -C target go
+
+# upload the binary to GH
+if [[ ! -x ./uploadAssetsToGHRelease.sh ]]; then 
+    curl -sSLO "https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/${MIDSTM_BRANCH}/product/uploadAssetsToGHRelease.sh" && chmod +x uploadAssetsToGHRelease.sh
+fi
+./uploadAssetsToGHRelease.sh --publish-assets -v "${CSV_VERSION}" -b "${MIDSTM_BRANCH}" -n ${ASSET_NAME} "${tarball}"
+
+${PODMAN} rmi -f ${GOLANG_IMAGE}

--- a/codeready-workspaces-stacks-golang/get-sources.sh
+++ b/codeready-workspaces-stacks-golang/get-sources.sh
@@ -5,18 +5,48 @@ scratchFlag=""
 JOB_BRANCH=""
 doRhpkgContainerBuild=1
 forceBuild=0
-pullAssets=0
+PULL_ASSETS=0
+DELETE_ASSETS=0
+PUBLISH_ASSETS=0
 generateDockerfileLABELs=1
+ASSET_NAME="golang"
+
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
 	'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
 	'-f'|'--force-build') forceBuild=1; shift 0;;
-	'-p'|'--pull-assets') pullAssets=1; shift 0;;
+	'-d'|'--delete-assets') DELETE_ASSETS=1; shift 0;;
+	'-a'|'--publish-assets') PUBLISH_ASSETS=1; shift 0;;
+	'-p'|'--pull-assets') PULL_ASSETS=1; shift 0;;
 	'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
+	'-v') CSV_VERSION="$2"; shift 1;;
 	*) JOB_BRANCH="$1"; shift 0;;
 	esac
 	shift 1
 done
+
+function log()
+{
+	if [[ ${verbose} -gt 0 ]]; then
+	echo "$1"
+	fi
+}
+
+if [[ ! -x ./uploadAssetsToGHRelease.sh ]]; then 
+    curl -sSLO "https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/${MIDSTM_BRANCH}/product/uploadAssetsToGHRelease.sh" && chmod +x uploadAssetsToGHRelease.sh
+fi
+
+if [[ ${DELETE_ASSETS} -eq 1 ]]; then
+	log "[INFO] Delete Previous GitHub Releases:"
+	./uploadAssetsToGHRelease.sh --delete-assets -v "${CSV_VERSION}" -n ${ASSET_NAME}
+	exit 0;
+fi
+
+if [[ ${PUBLISH_ASSETS} -eq 1 ]]; then
+	log "[INFO] Build Assets and Publish to GitHub Releases:"
+	./build/build.sh -v ${CSV_VERSION} -n ${ASSET_NAME}
+	exit 0;
+fi 
 
 # if not set, compute from current branch
 if [[ ! ${JOB_BRANCH} ]]; then 
@@ -25,198 +55,48 @@ if [[ ! ${JOB_BRANCH} ]]; then
 fi
 UPSTREAM_JOB_NAME="crw-deprecated_${JOB_BRANCH}"
 
-jenkinsURL=""
-checkJenkinsURL() {
-	checkURL="$1"
-	if [[ ! $(curl -sSLI ${checkURL} 2>&1 | grep -E "404|Not Found|Failed to connect|No route to host|Could not resolve host|Connection refused") ]]; then
-		jenkinsURL="$checkURL"
-	else
-		jenkinsURL=""
-	fi
-}
-# try local env var first
-if [[ ${JENKINS_URL} ]]; then 
-	checkJenkinsURL "${JENKINS_URL}job/CRW_CI/job/${UPSTREAM_JOB_NAME}"
-fi
-# new jenkins & path
-if [[ ! $jenkinsURL ]]; then
-	checkJenkinsURL "https://main-jenkins-csb-crwqe.apps.ocp4.prod.psi.redhat.com/job/CRW_CI/job/${UPSTREAM_JOB_NAME}"
-fi
-# old jenkins & path
-if [[ ! $jenkinsURL ]]; then
-	checkJenkinsURL "https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/${UPSTREAM_JOB_NAME}"
-fi
-if [[ ! $jenkinsURL ]]; then
-	echo "[ERROR] Cannot resolve artifact(s) for this build. Must abort!"
-	exit 1
-fi
-theTarGzs="
-lastSuccessfulBuild/artifact/codeready-workspaces-deprecated/golang/target/codeready-workspaces-stacks-language-servers-dependencies-golang-x86_64.tar.gz
-lastSuccessfulBuild/artifact/codeready-workspaces-deprecated/golang/target/codeready-workspaces-stacks-language-servers-dependencies-golang-s390x.tar.gz
-lastSuccessfulBuild/artifact/codeready-workspaces-deprecated/golang/target/codeready-workspaces-stacks-language-servers-dependencies-golang-ppc64le.tar.gz
-"
-lastSuccessfulURL="${jenkinsURL}/lastSuccessfulBuild/api/xml?xpath=/workflowRun/" # id
-function log()
-{
-	if [[ ${verbose} -gt 0 ]]; then
-	echo "$1"
-	fi
-}
-function logn()
-{
-	if [[ ${verbose} -gt 0 ]]; then
-	echo -n "$1"
-	fi
-}
-
-LABELs=""
-function addLabel () {
-	addLabeln "${1}" "${2}" "${3}"
-	echo ""
-}
-function addLabeln () {
-	LABEL_VAR=$1
-	if [[ "${2}" ]]; then LABEL_VAL=$2; else LABEL_VAL="${!LABEL_VAR}"; fi
-	if [[ "${3}" ]]; then PREFIX=$3; else PREFIX="	<< "; fi
-	if [[ ${generateDockerfileLABELs} -eq 1 ]]; then 
-		LABELs="${LABELs} ${LABEL_VAR}=\"${LABEL_VAL}\""
-	fi
-	echo -n "${PREFIX}${LABEL_VAL}"
-}
-
-function parseCommitLog () 
-{
-	# Update from Jenkins ::
-	# crw_master ::
-	# Build #246 (2019-02-26 04:23:36 EST) ::
-	# che-ls-jdt @ 288b75765175d368480a688c8f3a77ce4758c72d (0.0.3) ::
-	# che @ f34f4c6c82de35081351e0b0686b1ae6589735d4 (6.19.0-SNAPSHOT) ::
-	# codeready-workspaces @ 184e24bee5bd923b733fa8c9f4b055a9caad40d2 (1.1.0.GA) ::
-	# codeready-workspaces-deprecated @ 620a53c5b0a1bbc02ba68e96be94ec3b932c9bee ::
-	# codeready-workspaces-assembly-main.tar.gz
-	# codeready-workspaces-stacks-language-servers-dependencies-bayesian.tar.gz
-	# codeready-workspaces-stacks-language-servers-dependencies-node.tar.gz
-	tarballs=""
-	OTHER=""
-	JOB_NAME=""
-	GHE="https://github.com/eclipse/"
-	GHR="https://github.com/redhat-developer/"
-	while [[ "$#" -gt 0 ]]; do
-		case $1 in
-		'crw_master'|'crw_stable-branch'|'crw-deprecated_'*) JOB_NAME="$1"; shift 2;;
-		'Build'*) BUILD_NUMBER="$2"; BUILD_NUMBER=${BUILD_NUMBER#\#}; shift 6;; # trim # from the number, ignore timestamp
-		'che-dev'|'che-parent'|'che-lib'|'che-ls-jdt'|'che') 
-			sha="$3"; addLabeln "git.commit.eclipse__${1}" "${GHE}${1}/commit/${sha:0:7}"; addLabel "pom.version.eclipse__${1}" "${4:1:-1}" " "; shift 5;;
-		'codeready-workspaces')
-			sha="$3"; addLabeln "git.commit.redhat-developer__${1}" "${GHR}${1}/commit/${sha:0:7}"; addLabel "pom.version.redhat-developer__${1}" "${4:1:-1}" " "; shift 5;;
-		'codeready-workspaces-deprecated')
-			sha="$3"; addLabeln "git.commit.redhat-developer__${1}" "${GHR}${1}/commit/${sha:0:7}"; shift 4;;
-		*'tar.gz') tarballs="${tarballs} $1"; shift 1;;
-		*) OTHER="${OTHER} $1"; shift 1;; 
-		esac
-	done
-	if [[ $JOB_NAME ]]; then
-				jenkinsServer="${jenkinsURL%/job/*}"
-		addLabel "jenkins.build.url" "${jenkinsServer}/view/CRW_CI/view/Pipelines/job/${JOB_NAME}/${BUILD_NUMBER}/"
-		for t in $tarballs; do
-						addLabel "jenkins.artifact.url" "${jenkinsServer}/view/CRW_CI/view/Pipelines/job/${JOB_NAME}/${BUILD_NUMBER}/artifact/**/${t}" "		 ++ "
-		done
-	else
-		addLabel "jenkins.tarball.url" "${jenkinsServer}/view/CRW_CI/view/Pipelines #${BUILD_NUMBER} /${tarballs}"
-	fi
-}
-
-function insertLabels () {
-	DOCKERFILE=$1
-	# trim off the footer of the file
-	mv ${DOCKERFILE} ${DOCKERFILE}.bak
-	sed '/.*insert generated LABELs below this line.*/q' ${DOCKERFILE}.bak > ${DOCKERFILE}
-	# insert marker
-	if [[ ! $(cat ${DOCKERFILE}.bak | grep "insert generated LABELs below this line") ]]; then 
-		echo "" >> ${DOCKERFILE}
-		echo "" >> ${DOCKERFILE}
-		echo "# insert generated LABELs below this line" >> ${DOCKERFILE}
-	fi
-	# add new labels
-	echo "LABEL \\" >> ${DOCKERFILE}
-	for l in $LABELs; do
-				echo "			${l} \\" >> ${DOCKERFILE}
-	done
-		echo "			jenkins.build.number=\"${BUILD_NUMBER}\"" >> ${DOCKERFILE}
-	rm -f ${DOCKERFILE}.bak
-}
-
-function getFingerprints ()
-{
-	outputFile=$1
-	latestFingerprint="$(curl -L ${jenkinsURL}/lastSuccessfulBuild/fingerprints/ 2>&1 | grep ${outputFile} | sed -e "s#.\+/fingerprint/\([0-9a-f]\+\)/\".\+#\1#")"
-	currentFingerprint="$(cat sources | grep ${outputFile} | sed -e "s#\([0-9a-f]\+\) .\+#\1#")"
-}
-
-# get the public URL for the tarball(s)
-outputFiles=""
-
 #### override any existing tarballs with newer ones from Jenkins build
-for theTarGz in ${theTarGzs}; do
-	outputFile=${theTarGz##*/}
-	log "[INFO] Download ${jenkinsURL}/${theTarGz}:"
-	rm -f ${outputFile}
-	getFingerprints ${outputFile}
-	if [[ ! ${latestFingerprint} ]]; then 
-		echo "[WARNING] Cannot resolve artifact fingerprints for ${outputFile}"
-	fi
-	
-	if [[ "${latestFingerprint}" != "${currentFingerprint}" ]] || [[ ! -f ${outputFile} ]] || [[ ${pullAssets} -eq 1 ]]; then 
-		curl -L -o ${outputFile} ${jenkinsURL}/${theTarGz}
-		outputFiles="${outputFiles} ${outputFile}"
-	fi
-done
+log "[INFO] Download Assets:"
+./uploadAssetsToGHRelease.sh --pull-assets -v "${CSV_VERSION}" -n ${ASSET_NAME}
 
-if [[ ${outputFiles} ]]; then
-	log "[INFO] Upload new sources:${outputFiles}"
-	rhpkg new-sources ${outputFiles}
-	log "[INFO] Commit new sources from:${outputFiles}"
-	field=id; ID=$(curl -L -s -S ${lastSuccessfulURL}${field} | sed -e "s#<${field}>\(.\+\)</${field}>#\1#" -e "s#&lt;br/&gt; #\n#g" -e "s#\&lt;a.\+/a\&gt;##g")
-	if [[ $(echo $ID | grep -E "404 Not Found|ERROR 404|Application is not available") ]]; then 
-		echo $ID
-		echo "[ERROR] Problem loading ID from ${lastSuccessfulURL}${field} :: NOT FOUND!"
-		exit 1;
-	fi
-	COMMIT_MSG="Update from Jenkins :: ${UPSTREAM_JOB_NAME} :: ${ID}
-::${outputFiles}"
-	parseCommitLog ${COMMIT_MSG}
-	insertLabels Dockerfile
-	if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]] ;then 
-		log "[INFO] No new sources, so nothing to build."
-	elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
-		log "[INFO] Push change:"
-		git pull; git push; git status -s || true
-	fi
-	if [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
-		echo "[INFO] #1 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
-		git status || true
-		tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
-		taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
-		ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
-		if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
+#get names of the downloaded tarballs
+theTarGzs="$(ls *.tar.gz)"
 
-$ERRORS
-
-"; exit 1; fi
-	fi
-else
-	if [[ ${forceBuild} -eq 1 ]]; then
-		echo "[INFO] #2 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
-		git status || true
-		tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
-		taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
-		ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
-		if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
-
-$ERRORS
-
-"; exit 1; fi
-	else
-		log "[INFO] No new sources, so nothing to build."
-	fi
+log "[INFO] Upload new sources:${theTarGzs}"
+rhpkg new-sources ${theTarGzs}
+log "[INFO] Commit new sources from:${theTarGzs}"
+COMMIT_MSG="Update from GitHub Releases:: ${UPSTREAM_JOB_NAME} ::${theTarGzs}"
+if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]] ;then 
+	log "[INFO] No new sources, so nothing to build."
+elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
+	log "[INFO] Push change:"
+	git pull; git push; git status -s || true
 fi
+if [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
+	echo "[INFO] #1 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
+	git status || true
+	tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
+	taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
+	ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
+	if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
+
+$ERRORS
+
+"; exit 1; fi
+fi
+
+if [[ ${forceBuild} -eq 1 ]]; then
+	echo "[INFO] #2 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
+	git status || true
+	tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
+	taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
+	ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
+	if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
+
+$ERRORS
+
+"; exit 1; fi
+else
+	log "[INFO] No new sources, so nothing to build."
+fi
+

--- a/codeready-workspaces-stacks-golang/get-sources.sh
+++ b/codeready-workspaces-stacks-golang/get-sources.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -xe
-# script to get tarball(s) from Jenkins
+# script to get tarball(s) from GitHub Releases
 verbose=1
 scratchFlag=""
 JOB_BRANCH=""
@@ -55,7 +55,7 @@ if [[ ! ${JOB_BRANCH} ]]; then
 fi
 
 if [[ ${PULL_ASSETS} -eq 1 ]]; then
-	#### override any existing tarballs with newer ones from Jenkins build
+	#### override any existing tarballs with newer ones from asset build
 	log "[INFO] Download Assets:"
 	./uploadAssetsToGHRelease.sh --pull-assets -v "${CSV_VERSION}" -n ${ASSET_NAME}
 
@@ -65,7 +65,7 @@ if [[ ${PULL_ASSETS} -eq 1 ]]; then
 	log "[INFO] Upload new sources:${theTarGzs}"
 	rhpkg new-sources ${theTarGzs}
 	log "[INFO] Commit new sources from:${theTarGzs}"
-	COMMIT_MSG="Update from GitHub Releases:: ${ASSET_NAME} Assets ::${theTarGzs}"
+	COMMIT_MSG="chore: update from GH ${ASSET_NAME} assets :: ${theTarGzs}"
 	if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]] ;then 
 		log "[INFO] No new sources, so nothing to build."
 	elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then

--- a/codeready-workspaces-stacks-golang/get-sources.sh
+++ b/codeready-workspaces-stacks-golang/get-sources.sh
@@ -72,33 +72,32 @@ if [[ ${PULL_ASSETS} -eq 1 ]]; then
 		log "[INFO] Push change:"
 		git pull; git push; git status -s || true
 	fi
-fi
-
-if [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
-	echo "[INFO] #1 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
-	git status || true
-	tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
-	taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
-	ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
-	if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
+	if [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
+		echo "[INFO] #1 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
+		git status || true
+		tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
+		taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
+		ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
+		if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
 
 $ERRORS
 
 "; exit 1; fi
-fi
-
-if [[ ${forceBuild} -eq 1 ]]; then
-	echo "[INFO] #2 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
-	git status || true
-	tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
-	taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
-	ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
-	if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
-
-$ERRORS
-
-"; exit 1; fi
+	fi
 else
-	log "[INFO] No new sources, so nothing to build."
+	if [[ ${forceBuild} -eq 1 ]]; then
+		echo "[INFO] #2 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
+		git status || true
+		tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
+		taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
+		ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
+		if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
+
+$ERRORS
+
+"; exit 1; fi
+	else
+		log "[INFO] No new sources, so nothing to build."
+	fi
 fi
 

--- a/codeready-workspaces-stacks-golang/get-sources.sh
+++ b/codeready-workspaces-stacks-golang/get-sources.sh
@@ -65,7 +65,7 @@ if [[ ${PULL_ASSETS} -eq 1 ]]; then
 	log "[INFO] Upload new sources:${theTarGzs}"
 	rhpkg new-sources ${theTarGzs}
 	log "[INFO] Commit new sources from:${theTarGzs}"
-	COMMIT_MSG="Update from GitHub Releases:: ${UPSTREAM_JOB_NAME} ::${theTarGzs}"
+	COMMIT_MSG="Update from GitHub Releases:: ${ASSET_NAME} Assets ::${theTarGzs}"
 	if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]] ;then 
 		log "[INFO] No new sources, so nothing to build."
 	elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then

--- a/codeready-workspaces-stacks-php/build/build.sh
+++ b/codeready-workspaces-stacks-php/build/build.sh
@@ -19,8 +19,8 @@ export PHP_XDEBUG_IMAGE="php-xdebug:tmp"
 
 usage () {
     echo "
-Usage:   $0 -v [CRW CSV_VERSION] -n [GITHUB_RELEASE_NAME]
-Example: $0 -v 2.y.0 -n stacks-php
+Usage:   $0 -v [CRW CSV_VERSION] -n [ASSET_NAME]
+Example: $0 -v 2.y.0 -n php
 "
     exit
 }

--- a/codeready-workspaces-stacks-php/build/build.sh
+++ b/codeready-workspaces-stacks-php/build/build.sh
@@ -1,0 +1,94 @@
+#!/bin/bash -xe
+
+# Copyright (c) 2018-2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+# shellcheck disable=SC2155
+export SCRIPT_DIR=$(cd "$(dirname "$0")" || exit; pwd)
+export PHP_LS_VERSION=5.4.6
+export PHP_LS_IMAGE="php-ls:tmp"
+export PHP_XDEBUG_IMAGE="php-xdebug:tmp"
+
+usage () {
+    echo "
+Usage:   $0 -v [CRW CSV_VERSION] -n [GITHUB_RELEASE_NAME]
+Example: $0 -v 2.y.0 -n stacks-php
+"
+    exit
+}
+
+if [[ $# -lt 1 ]]; then usage; fi
+
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    '-v') CSV_VERSION="$2"; shift 1;;
+    '-n') ASSET_NAME="$2"; shift 1;;
+    '--help'|'-h') usage;;
+  esac
+  shift 1
+done
+
+cd "$SCRIPT_DIR"
+[[ -e target ]] && rm -Rf target
+
+echo ""
+echo "CodeReady Workspaces :: Stacks :: Language Servers :: PHP Dependencies"
+echo ""
+
+mkdir -p target/php-ls
+
+PODMAN=$(command -v podman || true)
+if [[ ! -x $PODMAN ]]; then
+  echo "[WARNING] podman is not installed."
+ PODMAN=$(command -v docker || true)
+  if [[ ! -x $PODMAN ]]; then
+    echo "[ERROR] docker is not installed. Aborting."; exit 1
+  fi
+fi
+
+ARCH="$(uname -m)"
+if [[ ! ${WORKSPACE} ]]; then WORKSPACE=/tmp; fi
+tarball_php="${WORKSPACE}/codeready-workspaces-stacks-language-servers-dependencies-${ASSET_NAME}-${ARCH}.tar.gz"
+tarball_php_xdebug="${WORKSPACE}/codeready-workspaces-stacks-language-servers-dependencies-${ASSET_NAME}-xdebug-${ARCH}.tar.gz"
+
+${PODMAN} build . -t ${PHP_LS_IMAGE} -f php-ls.Dockerfile
+${PODMAN} run --rm -v "$SCRIPT_DIR"/target/php-ls:/php ${PHP_LS_IMAGE} sh -c "
+    cd /php
+    /usr/local/bin/composer require jetbrains/phpstorm-stubs:dev-master
+    /usr/local/bin/composer require felixfbecker/language-server:${PHP_LS_VERSION}
+    /usr/local/bin/composer run-script --working-dir=vendor/felixfbecker/language-server parse-stubs
+    mv vendor/* .
+    rm -rf vendor
+    cp /usr/local/bin/composer /php/composer
+    chmod -R 777 /php/*
+    "
+tar -czf "${tarball_php}" -C target/php-ls .
+
+# upload the binary to GH
+if [[ ! -x ./uploadAssetsToGHRelease.sh ]]; then 
+    curl -sSLO "https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/${MIDSTM_BRANCH}/product/uploadAssetsToGHRelease.sh" && chmod +x uploadAssetsToGHRelease.sh
+fi
+./uploadAssetsToGHRelease.sh --publish-assets -v "${CSV_VERSION}" -b "${MIDSTM_BRANCH}" -n ${ASSET_NAME} "${tarball_php}"
+
+mkdir -p target/php-xdebug
+${PODMAN} build . -t ${PHP_XDEBUG_IMAGE} -f xdebug.Dockerfile
+${PODMAN} run -v "$SCRIPT_DIR"/target/php-xdebug:/xd ${PHP_XDEBUG_IMAGE} sh -c "
+    mkdir -p /xd/etc /xd/usr/share/doc/pecl/xdebug /xd/usr/lib64/php/modules/
+    cp /etc/php.ini /xd/etc/php.ini
+    cp -r /usr/share/doc/pecl/xdebug/* /xd/usr/share/doc/pecl/xdebug/
+    cp /usr/lib64/php/modules/xdebug.so /xd/usr/lib64/php/modules/xdebug.so
+    chmod -R 777 /xd
+    "
+tar -czf "${tarball_php_xdebug}" -C target/php-xdebug .
+
+./uploadAssetsToGHRelease.sh --publish-assets -v "${CSV_VERSION}" -b "${MIDSTM_BRANCH}" -n ${ASSET_NAME} "${tarball_php_xdebug}"
+
+${PODMAN} rmi -f ${PHP_LS_IMAGE} ${PHP_XDEBUG_IMAGE}

--- a/codeready-workspaces-stacks-php/build/php-ls.Dockerfile
+++ b/codeready-workspaces-stacks-php/build/php-ls.Dockerfile
@@ -1,0 +1,17 @@
+# Copyright (c) 2018-2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/php-74
+FROM registry.access.redhat.com/ubi8/php-74:1-28 as builder
+USER root
+RUN mkdir -p /php && cd /php && chmod -R 777 /php && \
+    wget https://getcomposer.org/installer -O /tmp/composer-installer.php && \
+    php /tmp/composer-installer.php --filename=composer --install-dir=/usr/local/bin

--- a/codeready-workspaces-stacks-php/build/xdebug.Dockerfile
+++ b/codeready-workspaces-stacks-php/build/xdebug.Dockerfile
@@ -1,0 +1,22 @@
+# Copyright (c) 2018-2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/php-74
+FROM registry.access.redhat.com/ubi8/php-74:1-28 as builder
+USER root
+RUN dnf install -y diffutils findutils php-fpm php-opcache php-devel php-pear php-gd php-mysqli php-zlib php-curl ca-certificates && \
+    pecl channel-update pecl.php.net && \
+    pecl install xdebug
+RUN echo -e "zend_extension=$(find /usr/lib64/php/modules -name xdebug.so)\n\
+xdebug.client_port = 9000\n\
+xdebug.mode = debug\n\
+xdebug.start_with_request = yes\n\
+xdebug.remote_log=/tmp/xdebug.log" > /etc/php.ini

--- a/codeready-workspaces-stacks-php/get-sources.sh
+++ b/codeready-workspaces-stacks-php/get-sources.sh
@@ -66,33 +66,31 @@ if [[ ${PULL_ASSETS} -eq 1 ]]; then
 		log "[INFO] Push change:"
 		git pull; git push; git status -s || true
 	fi
-fi
-
-if [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
-	echo "[INFO] #1 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
-	git status || true
-	tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
-	taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
-	ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
-	if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
+	if [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
+		echo "[INFO] #1 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
+		git status || true
+		tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
+		taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
+		ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
+		if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
 
 $ERRORS
 
 "; exit 1; fi
-fi
-
-if [[ ${forceBuild} -eq 1 ]]; then
-	echo "[INFO] #2 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
-	git status || true
-	tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
-	taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
-	ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
-	if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
-
-$ERRORS
-
-"; exit 1; fi
+	fi
 else
-	log "[INFO] No new sources, so nothing to build."
-fi
+	if [[ ${forceBuild} -eq 1 ]]; then
+		echo "[INFO] #2 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
+		git status || true
+		tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
+		taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
+		ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
+		if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
 
+$ERRORS
+
+"; exit 1; fi
+	else
+		log "[INFO] No new sources, so nothing to build."
+	fi
+fi

--- a/codeready-workspaces-stacks-php/get-sources.sh
+++ b/codeready-workspaces-stacks-php/get-sources.sh
@@ -48,23 +48,26 @@ if [[ ${PUBLISH_ASSETS} -eq 1 ]]; then
 	exit 0;
 fi
 
-#### override any existing tarballs with newer ones from Jenkins build
-log "[INFO] Download Assets:"
-./uploadAssetsToGHRelease.sh --pull-assets -v "${CSV_VERSION}" -n ${ASSET_NAME}
+if [[ ${PULL_ASSETS} -eq 1 ]]; then
+	#### override any existing tarballs with newer ones from Jenkins build
+	log "[INFO] Download Assets:"
+	./uploadAssetsToGHRelease.sh --pull-assets -v "${CSV_VERSION}" -n ${ASSET_NAME}
 
-#get names of the downloaded tarballs
-theTarGzs="$(ls *.tar.gz)"
+	#get names of the downloaded tarballs
+	theTarGzs="$(ls *.tar.gz)"
 
-log "[INFO] Upload new sources:${theTarGzs}"
-rhpkg new-sources ${theTarGzs}
-log "[INFO] Commit new sources from:${theTarGzs}"
-COMMIT_MSG="Update from Jenkins :: ${UPSTREAM_JOB_NAME} ::${theTarGzs}"
-if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]] ;then 
-	log "[INFO] No new sources, so nothing to build."
-elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
-	log "[INFO] Push change:"
-	git pull; git push; git status -s || true
+	log "[INFO] Upload new sources:${theTarGzs}"
+	rhpkg new-sources ${theTarGzs}
+	log "[INFO] Commit new sources from:${theTarGzs}"
+	COMMIT_MSG="Update from Jenkins :: ${UPSTREAM_JOB_NAME} ::${theTarGzs}"
+	if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]] ;then 
+		log "[INFO] No new sources, so nothing to build."
+	elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
+		log "[INFO] Push change:"
+		git pull; git push; git status -s || true
+	fi
 fi
+
 if [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
 	echo "[INFO] #1 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
 	git status || true

--- a/codeready-workspaces-stacks-php/get-sources.sh
+++ b/codeready-workspaces-stacks-php/get-sources.sh
@@ -5,211 +5,91 @@ scratchFlag=""
 JOB_BRANCH=""
 doRhpkgContainerBuild=1
 forceBuild=0
-pullAssets=0
+PULL_ASSETS=0
+DELETE_ASSETS=0
+PUBLISH_ASSETS=0
 generateDockerfileLABELs=1
+ASSET_NAME="php"
+
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
 	'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
 	'-f'|'--force-build') forceBuild=1; shift 0;;
-	'-p'|'--pull-assets') pullAssets=1; shift 0;;
+	'-d'|'--delete-assets') DELETE_ASSETS=1; shift 0;;
+	'-a'|'--publish-assets') PUBLISH_ASSETS=1; shift 0;;
+	'-p'|'--pull-assets') PULL_ASSETS=1; shift 0;;
 	'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
+	'-v') CSV_VERSION="$2"; shift 1;;
 	*) JOB_BRANCH="$1"; shift 0;;
 	esac
 	shift 1
 done
-UPSTREAM_JOB_NAME="crw-deprecated_${JOB_BRANCH}"
 
-jenkinsURL=""
-checkJenkinsURL() {
-	checkURL="$1"
-	if [[ ! $(curl -sSLI ${checkURL} 2>&1 | grep -E "404|Not Found|Failed to connect|No route to host|Could not resolve host|Connection refused") ]]; then
-		jenkinsURL="$checkURL"
-	else
-		jenkinsURL=""
-	fi
-}
-# try local env var first
-if [[ ${JENKINS_URL} ]]; then 
-	checkJenkinsURL "${JENKINS_URL}job/CRW_CI/job/${UPSTREAM_JOB_NAME}"
-fi
-# new jenkins & path
-if [[ ! $jenkinsURL ]]; then
-	checkJenkinsURL "https://main-jenkins-csb-crwqe.apps.ocp4.prod.psi.redhat.com/job/CRW_CI/job/${UPSTREAM_JOB_NAME}"
-fi
-# old jenkins & path
-if [[ ! $jenkinsURL ]]; then
-	checkJenkinsURL "https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/${UPSTREAM_JOB_NAME}"
-fi
-if [[ ! $jenkinsURL ]]; then
-	echo "[ERROR] Cannot resolve artifact(s) for this build. Must abort!"
-	exit 1
-fi
-theTarGzs="
-lastSuccessfulBuild/artifact/codeready-workspaces-deprecated/php/target/codeready-workspaces-stacks-language-servers-dependencies-php-x86_64.tar.gz
-lastSuccessfulBuild/artifact/codeready-workspaces-deprecated/php/target/codeready-workspaces-stacks-language-servers-dependencies-php-xdebug-x86_64.tar.gz
-lastSuccessfulBuild/artifact/codeready-workspaces-deprecated/php/target/codeready-workspaces-stacks-language-servers-dependencies-php-s390x.tar.gz
-lastSuccessfulBuild/artifact/codeready-workspaces-deprecated/php/target/codeready-workspaces-stacks-language-servers-dependencies-php-xdebug-s390x.tar.gz
-lastSuccessfulBuild/artifact/codeready-workspaces-deprecated/php/target/codeready-workspaces-stacks-language-servers-dependencies-php-ppc64le.tar.gz
-lastSuccessfulBuild/artifact/codeready-workspaces-deprecated/php/target/codeready-workspaces-stacks-language-servers-dependencies-php-xdebug-ppc64le.tar.gz
-"
-lastSuccessfulURL="${jenkinsURL}/lastSuccessfulBuild/api/xml?xpath=/workflowRun/" # id
 function log()
 {
 	if [[ ${verbose} -gt 0 ]]; then
 	echo "$1"
 	fi
 }
-function logn()
-{
-	if [[ ${verbose} -gt 0 ]]; then
-	echo -n "$1"
-	fi
-}
 
-LABELs=""
-function addLabel () {
-	addLabeln "${1}" "${2}" "${3}"
-	echo ""
-}
-function addLabeln () {
-	LABEL_VAR=$1
-	if [[ "${2}" ]]; then LABEL_VAL=$2; else LABEL_VAL="${!LABEL_VAR}"; fi
-	if [[ "${3}" ]]; then PREFIX=$3; else PREFIX="	<< "; fi
-	if [[ ${generateDockerfileLABELs} -eq 1 ]]; then 
-		LABELs="${LABELs} ${LABEL_VAR}=\"${LABEL_VAL}\""
-	fi
-	echo -n "${PREFIX}${LABEL_VAL}"
-}
+if [[ ! -x ./uploadAssetsToGHRelease.sh ]]; then 
+    curl -sSLO "https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/${MIDSTM_BRANCH}/product/uploadAssetsToGHRelease.sh" && chmod +x uploadAssetsToGHRelease.sh
+fi
 
-function parseCommitLog () 
-{
-	# Update from Jenkins ::
-	# crw_master ::
-	# Build #246 (2019-02-26 04:23:36 EST) ::
-	# che-ls-jdt @ 288b75765175d368480a688c8f3a77ce4758c72d (0.0.3) ::
-	# che @ f34f4c6c82de35081351e0b0686b1ae6589735d4 (6.19.0-SNAPSHOT) ::
-	# codeready-workspaces @ 184e24bee5bd923b733fa8c9f4b055a9caad40d2 (1.1.0.GA) ::
-	# codeready-workspaces-deprecated @ 620a53c5b0a1bbc02ba68e96be94ec3b932c9bee ::
-	# codeready-workspaces-assembly-main.tar.gz
-	# codeready-workspaces-stacks-language-servers-dependencies-bayesian.tar.gz
-	# codeready-workspaces-stacks-language-servers-dependencies-node.tar.gz
-	tarballs=""
-	OTHER=""
-	JOB_NAME=""
-	GHE="https://github.com/eclipse/"
-	GHR="https://github.com/redhat-developer/"
-	while [[ "$#" -gt 0 ]]; do
-		case $1 in
-		'crw_master'|'crw_stable-branch'|'crw-deprecated_'*) JOB_NAME="$1"; shift 2;;
-		'Build'*) BUILD_NUMBER="$2"; BUILD_NUMBER=${BUILD_NUMBER#\#}; shift 6;; # trim # from the number, ignore timestamp
-		'che-dev'|'che-parent'|'che-lib'|'che-ls-jdt'|'che') 
-			sha="$3"; addLabeln "git.commit.eclipse__${1}" "${GHE}${1}/commit/${sha:0:7}"; addLabel "pom.version.eclipse__${1}" "${4:1:-1}" " "; shift 5;;
-		'codeready-workspaces')
-			sha="$3"; addLabeln "git.commit.redhat-developer__${1}" "${GHR}${1}/commit/${sha:0:7}"; addLabel "pom.version.redhat-developer__${1}" "${4:1:-1}" " "; shift 5;;
-		'codeready-workspaces-deprecated')
-			sha="$3"; addLabeln "git.commit.redhat-developer__${1}" "${GHR}${1}/commit/${sha:0:7}"; shift 4;;
-		*'tar.gz') tarballs="${tarballs} $1"; shift 1;;
-		*) OTHER="${OTHER} $1"; shift 1;; 
-		esac
-	done
-	if [[ $JOB_NAME ]]; then
-				jenkinsServer="${jenkinsURL%/job/*}"
-		addLabel "jenkins.build.url" "${jenkinsServer}/view/CRW_CI/view/Pipelines/job/${JOB_NAME}/${BUILD_NUMBER}/"
-		for t in $tarballs; do
-						addLabel "jenkins.artifact.url" "${jenkinsServer}/view/CRW_CI/view/Pipelines/job/${JOB_NAME}/${BUILD_NUMBER}/artifact/**/${t}" "		 ++ "
-		done
-	else
-		addLabel "jenkins.tarball.url" "${jenkinsServer}/view/CRW_CI/view/Pipelines #${BUILD_NUMBER} /${tarballs}"
-	fi
-}
+if [[ ${DELETE_ASSETS} -eq 1 ]]; then
+	log "[INFO] Delete Previous GitHub Releases:"
+	./uploadAssetsToGHRelease.sh --delete-assets -v "${CSV_VERSION}" -n ${ASSET_NAME}
+	exit 0;
+fi
 
-function insertLabels () {
-	DOCKERFILE=$1
-	# trim off the footer of the file
-	mv ${DOCKERFILE} ${DOCKERFILE}.bak
-	sed '/.*insert generated LABELs below this line.*/q' ${DOCKERFILE}.bak > ${DOCKERFILE}
-	# insert marker
-	if [[ ! $(cat ${DOCKERFILE}.bak | grep "insert generated LABELs below this line") ]]; then 
-		echo "" >> ${DOCKERFILE}
-		echo "" >> ${DOCKERFILE}
-		echo "# insert generated LABELs below this line" >> ${DOCKERFILE}
-	fi
-	# add new labels
-	echo "LABEL \\" >> ${DOCKERFILE}
-	for l in $LABELs; do
-				echo "			${l} \\" >> ${DOCKERFILE}
-	done
-		echo "			jenkins.build.number=\"${BUILD_NUMBER}\"" >> ${DOCKERFILE}
-	rm -f ${DOCKERFILE}.bak
-}
-
-function getFingerprints ()
-{
-	outputFile=$1
-	latestFingerprint="$(curl -L ${jenkinsURL}/lastSuccessfulBuild/fingerprints/ | grep ${outputFile} | sed -e "s#.\+/fingerprint/\([0-9a-f]\+\)/\".\+#\1#")"
-	currentFingerprint="$(cat sources | grep ${outputFile} | sed -e "s#\([0-9a-f]\+\) .\+#\1#")"
-}
-
-# get the public URL for the tarball(s)
-outputFiles=""
+if [[ ${PUBLISH_ASSETS} -eq 1 ]]; then
+	log "[INFO] Build Assets and Publish to GitHub Releases:"
+	./build/build.sh -v ${CSV_VERSION} -n ${ASSET_NAME}
+	exit 0;
+fi
 
 #### override any existing tarballs with newer ones from Jenkins build
-for theTarGz in ${theTarGzs}; do
-	outputFile=${theTarGz##*/}
-	log "[INFO] Download ${jenkinsURL}/${theTarGz}:"
-	rm -f ${outputFile}
-	getFingerprints ${outputFile}
-	if [[ "${latestFingerprint}" != "${currentFingerprint}" ]] || [[ ! -f ${outputFile} ]] || [[ ${pullAssets} -eq 1 ]]; then 
-		curl -L -o ${outputFile} ${jenkinsURL}/${theTarGz}
-		outputFiles="${outputFiles} ${outputFile}"
-	fi
-done
+log "[INFO] Download Assets:"
+./uploadAssetsToGHRelease.sh --pull-assets -v "${CSV_VERSION}" -n ${ASSET_NAME}
 
-if [[ ${outputFiles} ]]; then
-	log "[INFO] Upload new sources:${outputFiles}"
-	rhpkg new-sources ${outputFiles}
-	log "[INFO] Commit new sources from:${outputFiles}"
-	field=id; ID=$(curl -L -s -S ${lastSuccessfulURL}${field} | sed -e "s#<${field}>\(.\+\)</${field}>#\1#" -e "s#&lt;br/&gt; #\n#g" -e "s#\&lt;a.\+/a\&gt;##g")
-	if [[ $(echo $ID | grep -E "404 Not Found|ERROR 404|Application is not available") ]]; then 
-		echo $ID
-		echo "[ERROR] Problem loading ID from ${lastSuccessfulURL}${field} :: NOT FOUND!"
-		exit 1;
-	fi
-	COMMIT_MSG="Update from Jenkins :: ${UPSTREAM_JOB_NAME} :: ${ID}
-::${outputFiles}"
-	parseCommitLog ${COMMIT_MSG}
-	insertLabels Dockerfile
-	if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]] ;then 
-		log "[INFO] No new sources, so nothing to build."
-	elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
-		log "[INFO] Push change:"
-		git pull; git push; git status -s || true
-	fi
-	if [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
-		echo "[INFO] #1 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
-		git status || true
-		tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
-		taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
-		ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
-		if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
+#get names of the downloaded tarballs
+theTarGzs="$(ls *.tar.gz)"
 
-$ERRORS
-
-"; exit 1; fi
-	fi
-else
-	if [[ ${forceBuild} -eq 1 ]]; then
-		echo "[INFO] #2 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
-		git status || true
-		tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
-		taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
-		ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
-		if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
-
-$ERRORS
-
-"; exit 1; fi
-	else
-		log "[INFO] No new sources, so nothing to build."
-	fi
+log "[INFO] Upload new sources:${theTarGzs}"
+rhpkg new-sources ${theTarGzs}
+log "[INFO] Commit new sources from:${theTarGzs}"
+COMMIT_MSG="Update from Jenkins :: ${UPSTREAM_JOB_NAME} ::${theTarGzs}"
+if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]] ;then 
+	log "[INFO] No new sources, so nothing to build."
+elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
+	log "[INFO] Push change:"
+	git pull; git push; git status -s || true
 fi
+if [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
+	echo "[INFO] #1 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
+	git status || true
+	tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
+	taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
+	ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
+	if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
+
+$ERRORS
+
+"; exit 1; fi
+fi
+
+if [[ ${forceBuild} -eq 1 ]]; then
+	echo "[INFO] #2 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
+	git status || true
+	tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
+	taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
+	ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
+	if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
+
+$ERRORS
+
+"; exit 1; fi
+else
+	log "[INFO] No new sources, so nothing to build."
+fi
+

--- a/codeready-workspaces-stacks-php/get-sources.sh
+++ b/codeready-workspaces-stacks-php/get-sources.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -xe
-# script to get tarball(s) from Jenkins
+# script to get tarball(s) from GitHub Releases
 verbose=1
 scratchFlag=""
 JOB_BRANCH=""
@@ -49,7 +49,7 @@ if [[ ${PUBLISH_ASSETS} -eq 1 ]]; then
 fi
 
 if [[ ${PULL_ASSETS} -eq 1 ]]; then
-	#### override any existing tarballs with newer ones from Jenkins build
+	#### override any existing tarballs with newer ones from asset build
 	log "[INFO] Download Assets:"
 	./uploadAssetsToGHRelease.sh --pull-assets -v "${CSV_VERSION}" -n ${ASSET_NAME}
 
@@ -59,7 +59,7 @@ if [[ ${PULL_ASSETS} -eq 1 ]]; then
 	log "[INFO] Upload new sources:${theTarGzs}"
 	rhpkg new-sources ${theTarGzs}
 	log "[INFO] Commit new sources from:${theTarGzs}"
-	COMMIT_MSG="Update from Jenkins :: ${ASSET_NAME} Assets ::${theTarGzs}"
+	COMMIT_MSG="chore: update from GH ${ASSET_NAME} assets :: ${theTarGzs}"
 	if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]] ;then 
 		log "[INFO] No new sources, so nothing to build."
 	elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then

--- a/codeready-workspaces-stacks-php/get-sources.sh
+++ b/codeready-workspaces-stacks-php/get-sources.sh
@@ -59,7 +59,7 @@ if [[ ${PULL_ASSETS} -eq 1 ]]; then
 	log "[INFO] Upload new sources:${theTarGzs}"
 	rhpkg new-sources ${theTarGzs}
 	log "[INFO] Commit new sources from:${theTarGzs}"
-	COMMIT_MSG="Update from Jenkins :: ${UPSTREAM_JOB_NAME} ::${theTarGzs}"
+	COMMIT_MSG="Update from Jenkins :: ${ASSET_NAME} Assets ::${theTarGzs}"
 	if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]] ;then 
 		log "[INFO] No new sources, so nothing to build."
 	elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then

--- a/codeready-workspaces-theia-dev/get-sources.sh
+++ b/codeready-workspaces-theia-dev/get-sources.sh
@@ -5,16 +5,16 @@ scratchFlag=""
 JOB_BRANCH=""
 doRhpkgContainerBuild=1
 forceBuild=0
-# NOTE: pullAssets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
+# NOTE: --pull-assets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
 # here we want to collect assets during sync-to-downsteam (using get-sources.sh -n -p)
 # so that rhpkg build is simply a brew wrapper (using get-sources.sh -f)
-pullAssets=0
+PULL_ASSETS=0
 
 while [[ "$#" -gt 0 ]]; do
   case $1 in
-  '-p'|'--pull-assets') pullAssets=1; shift 0;;
+  '-p'|'--pull-assets') PULL_ASSETS=1; shift 0;;
   '-a'|'--publish-assets') exit 0; shift 0;;
-	'-d'|'--delete-assets') exit 0; shift 0;;
+  '-d'|'--delete-assets') exit 0; shift 0;;
   '-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
   '-f'|'--force-build') forceBuild=1; shift 0;;
   '-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
@@ -46,7 +46,7 @@ function log()
 }
 
 OLD_SHA="$(git rev-parse --short=4 HEAD)"
-if [[ ${pullAssets} -eq 1 ]]; then 
+if [[ ${PULL_ASSETS} -eq 1 ]]; then 
   # collect assets. NOTE: target folder must end in theia-dev/, theia/ or theia-endpoint/ to auto-compute what to collect; 
   # otherwise an override flag is needed: -d, --theia-dev, -t, --theia, -e, --theia-endpoint
   ./build/scripts/collect-assets.sh --cb ${DWNSTM_BRANCH} --target $(pwd)/ --rmi:tmp --ci --commit

--- a/codeready-workspaces-theia-dev/get-sources.sh
+++ b/codeready-workspaces-theia-dev/get-sources.sh
@@ -13,9 +13,12 @@ pullAssets=0
 while [[ "$#" -gt 0 ]]; do
   case $1 in
   '-p'|'--pull-assets') pullAssets=1; shift 0;;
+  '-a'|'--publish-assets') exit 0; shift 0;;
+	'-d'|'--delete-assets') exit 0; shift 0;;
   '-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
   '-f'|'--force-build') forceBuild=1; shift 0;;
   '-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
+  '-v') CSV_VERSION="$2"; shift 1;;
   *) JOB_BRANCH="$1"; shift 0;;
   esac
   shift 1

--- a/codeready-workspaces-theia-endpoint/get-sources.sh
+++ b/codeready-workspaces-theia-endpoint/get-sources.sh
@@ -5,16 +5,16 @@ scratchFlag=""
 JOB_BRANCH=""
 doRhpkgContainerBuild=1
 forceBuild=0
-# NOTE: pullAssets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
+# NOTE: --pull-assets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
 # here we want to collect assets during sync-to-downsteam (using get-sources.sh -n -p)
 # so that rhpkg build is simply a brew wrapper (using get-sources.sh -f)
-pullAssets=0
+PULL_ASSETS=0
 
 while [[ "$#" -gt 0 ]]; do
   case $1 in
-  '-p'|'--pull-assets') pullAssets=1; shift 0;;
+  '-p'|'--pull-assets') PULL_ASSETS=1; shift 0;;
   '-a'|'--publish-assets') exit 0; shift 0;;
-	'-d'|'--delete-assets') exit 0; shift 0;;
+  '-d'|'--delete-assets') exit 0; shift 0;;
   '-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
   '-f'|'--force-build') forceBuild=1; shift 0;;
   '-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
@@ -46,7 +46,7 @@ function log()
 }
 
 OLD_SHA="$(git rev-parse --short=4 HEAD)"
-if [[ ${pullAssets} -eq 1 ]]; then 
+if [[ ${PULL_ASSETS} -eq 1 ]]; then 
   # collect assets. NOTE: target folder must end in theia-dev/, theia/ or theia-endpoint/ to auto-compute what to collect; 
   # otherwise an override flag is needed: -d, --theia-dev, -t, --theia, -e, --theia-endpoint
   ./build/scripts/collect-assets.sh --cb ${DWNSTM_BRANCH} --target $(pwd)/ --rmi:tmp --ci --commit

--- a/codeready-workspaces-theia-endpoint/get-sources.sh
+++ b/codeready-workspaces-theia-endpoint/get-sources.sh
@@ -13,9 +13,12 @@ pullAssets=0
 while [[ "$#" -gt 0 ]]; do
   case $1 in
   '-p'|'--pull-assets') pullAssets=1; shift 0;;
+  '-a'|'--publish-assets') exit 0; shift 0;;
+	'-d'|'--delete-assets') exit 0; shift 0;;
   '-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
   '-f'|'--force-build') forceBuild=1; shift 0;;
   '-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
+  '-v') CSV_VERSION="$2"; shift 1;;
   *) JOB_BRANCH="$1"; shift 0;;
   esac
   shift 1

--- a/codeready-workspaces-theia/get-sources.sh
+++ b/codeready-workspaces-theia/get-sources.sh
@@ -5,16 +5,16 @@ scratchFlag=""
 JOB_BRANCH=""
 doRhpkgContainerBuild=1
 forceBuild=0
-# NOTE: pullAssets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
+# NOTE: --pull-assets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
 # here we want to collect assets during sync-to-downsteam (using get-sources.sh -n -p)
 # so that rhpkg build is simply a brew wrapper (using get-sources.sh -f)
-pullAssets=0
+PULL_ASSETS=0
 
 while [[ "$#" -gt 0 ]]; do
   case $1 in
-  '-p'|'--pull-assets') pullAssets=1; shift 0;;
+  '-p'|'--pull-assets') PULL_ASSETS=1; shift 0;;
   '-a'|'--publish-assets') exit 0; shift 0;;
-	'-d'|'--delete-assets') exit 0; shift 0;;
+  '-d'|'--delete-assets') exit 0; shift 0;;
   '-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
   '-f'|'--force-build') forceBuild=1; shift 0;;
   '-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
@@ -46,7 +46,7 @@ function log()
 }
 
 OLD_SHA="$(git rev-parse --short=4 HEAD)"
-if [[ ${pullAssets} -eq 1 ]]; then 
+if [[ ${PULL_ASSETS} -eq 1 ]]; then 
   # collect assets. NOTE: target folder must end in theia-dev/, theia/ or theia-endpoint/ to auto-compute what to collect; 
   # otherwise an override flag is needed: -d, --theia-dev, -t, --theia, -e, --theia-endpoint
   ./build/scripts/collect-assets.sh --cb ${DWNSTM_BRANCH} --target $(pwd)/ --rmi:tmp --ci --commit

--- a/codeready-workspaces-theia/get-sources.sh
+++ b/codeready-workspaces-theia/get-sources.sh
@@ -13,9 +13,12 @@ pullAssets=0
 while [[ "$#" -gt 0 ]]; do
   case $1 in
   '-p'|'--pull-assets') pullAssets=1; shift 0;;
+  '-a'|'--publish-assets') exit 0; shift 0;;
+	'-d'|'--delete-assets') exit 0; shift 0;;
   '-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
   '-f'|'--force-build') forceBuild=1; shift 0;;
   '-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
+  '-v') CSV_VERSION="$2"; shift 1;;
   *) JOB_BRANCH="$1"; shift 0;;
   esac
   shift 1

--- a/codeready-workspaces-traefik/build/rhel.binary.build.sh
+++ b/codeready-workspaces-traefik/build/rhel.binary.build.sh
@@ -16,7 +16,6 @@ set -e
 
 # defaults
 CSV_VERSION=2.y.0 # csv 2.y.0
-SYNC_REPO="traefik"
 UPLOAD_TO_GH=1
 
 MIDSTM_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "crw-2-rhel-8")
@@ -35,9 +34,9 @@ if [[ $# -lt 1 ]]; then usage; fi
 while [[ "$#" -gt 0 ]]; do
   case $1 in
     '-v') CSV_VERSION="$2"; shift 1;;
-    '-b') MIDSTM_BRANCH="$2"; shift 1;;
     '-ght') GITHUB_TOKEN="$2"; export GITHUB_TOKEN="${GITHUB_TOKEN}"; shift 1;;
-    '-n'|'--noupload') UPLOAD_TO_GH=0;;
+    '-n') ASSET_NAME="$2"; shift 1;;
+    '--noupload') UPLOAD_TO_GH=0;;
     '--help'|'-h') usage;;
   esac
   shift 1
@@ -79,9 +78,9 @@ if [[ ${UPLOAD_TO_GH} -eq 1 ]]; then
       curl -sSLO "https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/${MIDSTM_BRANCH}/product/uploadAssetsToGHRelease.sh" && chmod +x uploadAssetsToGHRelease.sh
   fi
   # delete existing release & tag & assets -- this will remove everything for each push for each arch, so can't be done here
-  # ./uploadAssetsToGHRelease.sh --delete-assets -v "${CSV_VERSION}" -b "${MIDSTM_BRANCH}" --asset-name "${SYNC_REPO}"
+  # ./uploadAssetsToGHRelease.sh --delete-assets -v "${CSV_VERSION}" -b "${MIDSTM_BRANCH}" --asset-name "${ASSET_NAME}"
   # create a new release & tag w/ fresh assets
-  ./uploadAssetsToGHRelease.sh --publish-assets -v "${CSV_VERSION}" -b "${MIDSTM_BRANCH}" --asset-name "${SYNC_REPO}" "${tarball}"
+  ./uploadAssetsToGHRelease.sh --publish-assets -v "${CSV_VERSION}" -b "${MIDSTM_BRANCH}" --asset-name "${ASSET_NAME}" "${tarball}"
 
   # cleanup
   podman rmi -f $TMP_IMG

--- a/codeready-workspaces-traefik/build/rhel.binary.build.sh
+++ b/codeready-workspaces-traefik/build/rhel.binary.build.sh
@@ -23,8 +23,8 @@ if [[ ${MIDSTM_BRANCH} != "crw-"*"-rhel-"* ]]; then MIDSTM_BRANCH="crw-2-rhel-8"
 
 usage () {
     echo "
-Usage:   $0 -v [CRW CSV_VERSION] [--noupload] [-b MIDSTM_BRANCH] [-ght GITHUB_TOKEN]
-Example: $0 -v 2.y.0 --noupload
+Usage:   $0 -v [CRW CSV_VERSION] [--noupload] [-n ASSET_NAME] [-ght GITHUB_TOKEN]
+Example: $0 -v 2.y.0 -n traefik --noupload
 "
     exit
 }

--- a/codeready-workspaces-traefik/get-sources.sh
+++ b/codeready-workspaces-traefik/get-sources.sh
@@ -8,7 +8,10 @@ forceBuild=0
 # NOTE: pullAssets (-p) flag uses opposite behaviour to some other get-sources.sh scripts;
 # here we want to collect assets during sync-to-downsteam (using get-sources.sh -n -p)
 # so that rhpkg build is simply a brew wrapper (using get-sources.sh -f)
-pullAssets=0
+PULL_ASSETS=0
+PUBLISH_ASSETS=0
+DELETE_ASSETS=0
+ASSET_NAME="traefik"
 
 # compute project name from current dir
 SCRIPT_DIR=$(cd "$(dirname "$0")" || exit; pwd); 
@@ -25,12 +28,13 @@ CSV_VERSION=$(curl -sSLo- "https://raw.githubusercontent.com/redhat-developer/co
 
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
-		'-p'|'--pull-assets') pullAssets=1; shift 0;;
+		'-d'|'--delete-assets') DELETE_ASSETS=1; shift 0;;
+		'-a'|'--publish-assets') PUBLISH_ASSETS=1; shift 0;;
+		'-p'|'--pull-assets') PULL_ASSETS=1; shift 0;;
 		'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
 		'-f'|'--force-build') forceBuild=1; shift 0;;
 		'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
 		'-v') CSV_VERSION="$2"; shift 1;;
-		'-b') MIDSTM_BRANCH="$2"; shift 1;;
 		'-ght') GITHUB_TOKEN="$2"; shift 1;;
 	esac
 	shift 1
@@ -42,77 +46,65 @@ function log()
 	echo "$1"
 	fi
 }
-function logn()
-{
-	if [[ ${verbose} -gt 0 ]]; then
-	echo -n "$1"
-	fi
-}
 
-curlWithToken()
-{
-  curl -sSL -H "Authorization:token ${GITHUB_TOKEN}" "$1" "$2" "$3"
-}
-
-# check if existing release exists
-releases_URL="https://api.github.com/repos/redhat-developer/codeready-workspaces-images/releases"
-# shellcheck disable=2086
-RELEASE_ID=$(curlWithToken -H "Accept: application/vnd.github.v3+json" $releases_URL | jq -r --arg CSV_VERSION "${CSV_VERSION}" --arg projectName "${projectName}" '.[] | select(.name=="Assets for the '$CSV_VERSION' '$projectName' release")|.url' || true); RELEASE_ID=${RELEASE_ID##*/}
-if [[ -z $RELEASE_ID ]]; then 
-	echo "ERROR: could not compute RELEASE_ID from which to collect assets! Check https://api.github.com/repos/redhat-developer/codeready-workspaces-images/releases"
-	exit 1
+if [[ ! -x ./uploadAssetsToGHRelease.sh ]]; then 
+    curl -sSLO "https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/${MIDSTM_BRANCH}/product/uploadAssetsToGHRelease.sh" && chmod +x uploadAssetsToGHRelease.sh
 fi
 
-# get the public URLs for the tarball(s) from browser_download_url
-theTarGzs="$(curlWithToken https://api.github.com/repos/redhat-developer/codeready-workspaces-images/releases/${RELEASE_ID} | jq -r '.assets[].browser_download_url')"
+if [[ ${DELETE_ASSETS} -eq 1 ]]; then
+	log "[INFO] Delete Previous GitHub Releases:"
+	./uploadAssetsToGHRelease.sh --delete-assets -v "${CSV_VERSION}" -n ${ASSET_NAME}}
+	exit 0;
+fi
+
+if [[ ${PUBLISH_ASSETS} -eq 1 ]]; then
+	log "[INFO] Build Assets and Publish to GitHub Releases:"
+	./build/rhel.binary.build.sh -v ${CSV_VERSION} -n ${ASSET_NAME}
+	exit 0;
+fi
 
 #### override any existing tarballs with newer ones from Jenkins build
-for theTarGz in ${theTarGzs}; do
-	log "[INFO] Download ${theTarGz} -> ${theTarGz##*/}"
-	# TODO can we check if we already have the identical file before re-downloading it? eg., store sha512sums as assets files?
-	if [[ ! -f ./${theTarGz##*/} ]] || [[ ${pullAssets} -eq 1 ]]; then 
-		if [[ -f ./${theTarGz##*/} ]]; then rm -f ./${theTarGz##*/}; fi
-		curl -sSLo ./${theTarGz##*/} ${theTarGz}
-		outputFiles="${outputFiles} ${theTarGz##*/}"
-	fi
-done
+log "[INFO] Download Assets:"
+./uploadAssetsToGHRelease.sh --pull-assets -v "${CSV_VERSION}" -n ${ASSET_NAME}
 
-if [[ ${outputFiles} ]]; then
-	log "[INFO] Upload new sources: ${outputFiles}"
-	rhpkg new-sources ${outputFiles}
-	log "[INFO] Commit new sources from:${outputFiles}"
-	COMMIT_MSG="GH releases :: ${outputFiles}"
-	if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]]; then 
-		log "[INFO] No new sources, so nothing to build."
-	elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
-		log "[INFO] Push change:"
-		git pull; git push; git status -s || true
-	fi
-	if [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
-		echo "[INFO] #1 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
-		git status || true
-		tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
-		taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
-		ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
-		if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
+#get names of the downloaded tarballs
+theTarGzs="$(ls *.tar.gz)"
 
-$ERRORS
-
-"; exit 1; fi
-	fi
-else
-	if [[ ${forceBuild} -eq 1 ]]; then
-		echo "[INFO] #2 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
-		git status || true
-		tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
-		taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
-		ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
-		if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
-
-$ERRORS
-
-"; exit 1; fi
-	else
-		log "[INFO] No new sources, so nothing to build."
-	fi
+log "[INFO] Upload new sources: ${theTarGzs}"
+rhpkg new-sources ${theTarGzs}
+log "[INFO] Commit new sources from:${theTarGzs}"
+COMMIT_MSG="GH releases :: ${theTarGzs}"
+if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]]; then 
+	log "[INFO] No new sources, so nothing to build."
+elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
+	log "[INFO] Push change:"
+	git pull; git push; git status -s || true
 fi
+if [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
+	echo "[INFO] #1 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
+	git status || true
+	tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
+	taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
+	ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
+	if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
+
+$ERRORS
+
+"; exit 1; fi
+fi
+
+if [[ ${forceBuild} -eq 1 ]]; then
+	echo "[INFO] #2 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
+	git status || true
+	tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
+	taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
+	ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
+	if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
+
+$ERRORS
+
+"; exit 1; fi
+else
+	log "[INFO] No new sources, so nothing to build."
+fi
+

--- a/codeready-workspaces-traefik/get-sources.sh
+++ b/codeready-workspaces-traefik/get-sources.sh
@@ -64,7 +64,7 @@ if [[ ${PUBLISH_ASSETS} -eq 1 ]]; then
 fi
 
 if [[ ${PULL_ASSETS} -eq 1 ]]; then
-	#### override any existing tarballs with newer ones from Jenkins build
+	#### override any existing tarballs with newer ones from asset build
 	log "[INFO] Download Assets:"
 	./uploadAssetsToGHRelease.sh --pull-assets -v "${CSV_VERSION}" -n ${ASSET_NAME}
 
@@ -74,7 +74,7 @@ if [[ ${PULL_ASSETS} -eq 1 ]]; then
 	log "[INFO] Upload new sources: ${theTarGzs}"
 	rhpkg new-sources ${theTarGzs}
 	log "[INFO] Commit new sources from:${theTarGzs}"
-	COMMIT_MSG="GH releases :: ${theTarGzs}"
+	COMMIT_MSG="chore: update from GH ${ASSET_NAME} assets :: ${theTarGzs}"
 	if [[ $(git commit -s -m "ci: [get sources] ${COMMIT_MSG}" sources Dockerfile .gitignore) == *"nothing to commit, working tree clean"* ]]; then 
 		log "[INFO] No new sources, so nothing to build."
 	elif [[ ${doRhpkgContainerBuild} -eq 1 ]]; then

--- a/codeready-workspaces-traefik/get-sources.sh
+++ b/codeready-workspaces-traefik/get-sources.sh
@@ -81,33 +81,31 @@ if [[ ${PULL_ASSETS} -eq 1 ]]; then
 		log "[INFO] Push change:"
 		git pull; git push; git status -s || true
 	fi
-fi
-
-if [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
-	echo "[INFO] #1 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
-	git status || true
-	tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
-	taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
-	ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
-	if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
+	if [[ ${doRhpkgContainerBuild} -eq 1 ]]; then
+		echo "[INFO] #1 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
+		git status || true
+		tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
+		taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
+		ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
+		if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
 
 $ERRORS
 
 "; exit 1; fi
 fi
-
-if [[ ${forceBuild} -eq 1 ]]; then
-	echo "[INFO] #2 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
-	git status || true
-	tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
-	taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
-	ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
-	if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
-
-$ERRORS
-
-"; exit 1; fi
 else
-	log "[INFO] No new sources, so nothing to build."
-fi
+	if [[ ${forceBuild} -eq 1 ]]; then
+		echo "[INFO] #2 Trigger container-build in current branch: rhpkg container-build ${scratchFlag}"
+		git status || true
+		tmpfile=$(mktemp) && rhpkg container-build ${scratchFlag} --nowait | tee 2>&1 $tmpfile
+		taskID=$(cat $tmpfile | grep "Created task:" | sed -e "s#Created task:##") && brew watch-logs $taskID | tee 2>&1 $tmpfile
+		ERRORS="$(grep "image build failed" $tmpfile)" && rm -f $tmpfile
+		if [[ "$ERRORS" != "" ]]; then echo "Brew build has failed:
 
+$ERRORS
+
+"; exit 1; fi
+	else
+		log "[INFO] No new sources, so nothing to build."
+	fi
+fi

--- a/codeready-workspaces/get-sources.sh
+++ b/codeready-workspaces/get-sources.sh
@@ -12,6 +12,9 @@ while [[ "$#" -gt 0 ]]; do
 	'-f'|'--force-build') forceBuild=1; shift 0;;
 	'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
 	'-p'|'--pull-assets') pullAssets=1; shift 0;;
+	'-a'|'--publish-assets') exit 0; shift 0;;
+	'-d'|'--delete-assets') exit 0; shift 0;;
+	'-v') CSV_VERSION="$2"; shift 1;;
 	esac
 	shift 1
 done

--- a/codeready-workspaces/get-sources.sh
+++ b/codeready-workspaces/get-sources.sh
@@ -4,14 +4,14 @@
 scratchFlag=""
 doRhpkgContainerBuild=1
 forceBuild=0
-pullAssets=0
+PULL_ASSETS=0
 
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
 	'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
 	'-f'|'--force-build') forceBuild=1; shift 0;;
 	'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
-	'-p'|'--pull-assets') pullAssets=1; shift 0;;
+	'-p'|'--pull-assets') PULL_ASSETS=1; shift 0;;
 	'-a'|'--publish-assets') exit 0; shift 0;;
 	'-d'|'--delete-assets') exit 0; shift 0;;
 	'-v') CSV_VERSION="$2"; shift 1;;
@@ -21,7 +21,7 @@ done
 
 outputFile="asset-server.tgz"
 rm -f $outputFile .repository/
-if [[ ${pullAssets} -eq 1 ]]; then
+if [[ ${PULL_ASSETS} -eq 1 ]]; then
 	MVN_VER="3.6.3"
 	JDK_VER="11"
 	sudo yum -y install java-${JDK_VER}-openjdk java-${JDK_VER}-openjdk-devel


### PR DESCRIPTION
because that one became too convoluted to manage.

https://issues.redhat.com/browse/CRW-2081

Moving language servers out of their own repo and into crw-images
updating build.sh and get-sources files for new location and to use the uploadAssets scripts to push/pull assets from GH Releases.

Made some updates to configbump and traefik so they didnt get left behind