### PR TITLE
fix: Fix failing CRW 2.13 installation.

### DIFF
--- a/codeready-workspaces-operator-metadata/build/scripts/sync-che-olm-to-crw-olm.sh
+++ b/codeready-workspaces-operator-metadata/build/scripts/sync-che-olm-to-crw-olm.sh
@@ -256,7 +256,7 @@ for CSVFILE in ${TARGETDIR}/manifests/codeready-workspaces.csv.yaml; do
 	fi
 
 	# Disable by default devWorkspace engine in `latest` channel
-	CSV_CR_SAMPLES=$(yq -r ".metadata.annotations.\"alm-examples\"" "${CSVFILE}" | yq -r ".[0] | del(.spec.devWorkspace) | [.]"  | sed -r 's/"/\\"/g')
+	CSV_CR_SAMPLES=$(yq -r ".metadata.annotations.\"alm-examples\" | fromjson | .[] | select(.kind == \"CheCluster\") | del(.spec.devWorkspace) | [.]" "${CSVFILE}" | sed -r 's/"/\\"/g')
 	yq -riY ".metadata.annotations[\"alm-examples\"] = \"${CSV_CR_SAMPLES}\"" ${CSVFILE}
 	yq -Yi '.spec.customresourcedefinitions.owned[] |= (select(.name == "checlusters.org.eclipse.che").specDescriptors += [{"path":"devWorkspace", "x-descriptors": ["urn:alm:descriptor:com.tectonic.ui:hidden"]}])' "${CSVFILE}"
 


### PR DESCRIPTION
# What does this pr fix
https://issues.redhat.com/browse/CRW-2416

# What does this pr do
This pr should fix custom resource https://github.com/redhat-developer/codeready-workspaces-images/blob/5beb480ab9cff5f54bb6188d8ebfc9e472006155/codeready-workspaces-operator-metadata-generated/manifests/codeready-workspaces.csv.yaml#L23 . We have to use `CheCluster` CR instead of `CheBackupServerConfiguration`. 
Alternative(not covered in the pr): or we could use all CRs from che-operator CR.

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>