### PR TITLE
Merge fix for get-sources script

### DIFF
--- a/codeready-workspaces-configbump/get-sources.sh
+++ b/codeready-workspaces-configbump/get-sources.sh
@@ -65,7 +65,7 @@ fi
 
 if [[ ${PULL_ASSETS} -eq 1 ]]; then
 	log "[INFO] Download Assets:"
-	./uploadAssetsToGHRelease.sh --fetch-assets -v "${CSV_VERSION}" -n ${ASSET_NAME}
+	./uploadAssetsToGHRelease.sh --pull-assets -v "${CSV_VERSION}" -n ${ASSET_NAME}
 
 	#get names of the downloaded tarballs
 	theTarGzs="$(ls *.tar.gz)"

--- a/codeready-workspaces-plugin-kubernetes/get-sources.sh
+++ b/codeready-workspaces-plugin-kubernetes/get-sources.sh
@@ -70,7 +70,7 @@ if [[ $(diff -U 0 --suppress-common-lines -b Dockerfile Dockerfile.2) ]] || [[ $
 
 
 	log "[INFO] Download Assets:"
-	./uploadAssetsToGHRelease.sh --fetch-assets -v "${CSV_VERSION}" -n ${ASSET_NAME}
+	./uploadAssetsToGHRelease.sh --pull-assets -v "${CSV_VERSION}" -n ${ASSET_NAME}
 	
 	# x86
 	./kamel-${KAMEL_VERSION}-x86_64.tar.gz | tar -xz && mv kamel asset-x86_64-kamel


### PR DESCRIPTION
Fix: found 2 get-sources files that still used fetch-assets when they should be using pull-assets