### PR TITLE
fix: CRW-2535 - remove...

### DIFF
--- a/codeready-workspaces-operator-bundle/build/scripts/sync-che-olm-to-crw-olm.sh
+++ b/codeready-workspaces-operator-bundle/build/scripts/sync-che-olm-to-crw-olm.sh
@@ -321,6 +321,7 @@ for CSVFILE in ${TARGETDIR}/manifests/codeready-workspaces.csv.yaml; do
 		["RELATED_IMAGE_gateway_authorization_sidecar"]="${RBAC_PROXY_IMAGE}"
 
 		# remove env vars using DELETEME keyword
+		["RELATED_IMAGE_gateway_authorization_sidecar_k8s"]="DELETME"
 		["RELATED_IMAGE_che_tls_secrets_creation_job"]="DELETEME"
 		["RELATED_IMAGE_gateway_header_sidecar"]="DELETEME"
 	)

--- a/codeready-workspaces-operator-bundle/build/scripts/sync-che-operator-to-crw-operator.sh
+++ b/codeready-workspaces-operator-bundle/build/scripts/sync-che-operator-to-crw-operator.sh
@@ -231,6 +231,7 @@ declare -A operator_replacements=(
 	["RELATED_IMAGE_gateway_authorization_sidecar"]="${RBAC_PROXY_IMAGE}"
 
 	# remove env vars using DELETEME keyword
+	["RELATED_IMAGE_gateway_authorization_sidecar_k8s"]="DELETME"
 	["RELATED_IMAGE_che_tls_secrets_creation_job"]="DELETEME"
 	["RELATED_IMAGE_gateway_header_sidecar"]="DELETEME"
 )

--- a/codeready-workspaces-operator-metadata/build/scripts/sync-che-olm-to-crw-olm.sh
+++ b/codeready-workspaces-operator-metadata/build/scripts/sync-che-olm-to-crw-olm.sh
@@ -301,6 +301,7 @@ for CSVFILE in ${TARGETDIR}/manifests/codeready-workspaces.csv.yaml; do
 		["RELATED_IMAGE_gateway_authorization_sidecar"]="${RBAC_PROXY_IMAGE}"
 
 		# remove env vars using DELETEME keyword
+		["RELATED_IMAGE_gateway_authorization_sidecar_k8s"]="DELETME"
 		["RELATED_IMAGE_che_tls_secrets_creation_job"]="DELETEME"
 		["RELATED_IMAGE_gateway_header_sidecar"]="DELETEME"
 	)

--- a/codeready-workspaces-operator-metadata/build/scripts/sync-che-operator-to-crw-operator.sh
+++ b/codeready-workspaces-operator-metadata/build/scripts/sync-che-operator-to-crw-operator.sh
@@ -225,6 +225,7 @@ declare -A operator_replacements=(
 	["RELATED_IMAGE_gateway_authorization_sidecar"]="${RBAC_PROXY_IMAGE}"
 
 	# remove env vars using DELETEME keyword
+	["RELATED_IMAGE_gateway_authorization_sidecar_k8s"]="DELETME"
 	["RELATED_IMAGE_che_tls_secrets_creation_job"]="DELETEME"
 	["RELATED_IMAGE_gateway_header_sidecar"]="DELETEME"
 )

--- a/codeready-workspaces-operator/build/scripts/sync-che-operator-to-crw-operator.sh
+++ b/codeready-workspaces-operator/build/scripts/sync-che-operator-to-crw-operator.sh
@@ -224,6 +224,7 @@ declare -A operator_replacements=(
 	["RELATED_IMAGE_gateway_authorization_sidecar"]="${RBAC_PROXY_IMAGE}"
 
 	# remove env vars using DELETEME keyword
+	["RELATED_IMAGE_gateway_authorization_sidecar_k8s"]="DELETME"
 	["RELATED_IMAGE_che_tls_secrets_creation_job"]="DELETEME"
 	["RELATED_IMAGE_gateway_header_sidecar"]="DELETEME"
 )


### PR DESCRIPTION
### What does this PR do?

fix: CRW-2535 - remove RELATED_IMAGE_gateway_authorization_sidecar_k8s from CRW CSVs as only needed for upstream/k8s

Signed-off-by: nickboldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.