### PR TITLE
chore: Add test to check devfile templates generation

### DIFF
--- a/codeready-workspaces-devfileregistry/tests/basic-test.yaml
+++ b/codeready-workspaces-devfileregistry/tests/basic-test.yaml
@@ -35,5 +35,8 @@
         - name: Make sure httpd is present and folders are populated
           shell: oc exec {{ pod_name.stdout }} -- ls -las /var/www/html/ /var/www/html/devfiles
           register: ls_cmd_run
+        - name: Make sure devfile templates are generated
+          shell: oc exec {{ pod_name.stdout }} -- find /var/www/html/devfiles -name devworkspace-che-theia-latest.yaml | grep .
+          register: ls_cmd_run
         - debug:
             msg: "{{ ls_cmd_run.stdout }}"


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

 Add test which lists `devworkspace-che-theia-latest.yaml` in the `devfiles` directory, or returns `exit code 1`, if no templates found.