### PR TITLE
chore: add user into UDI

### DIFF
--- a/codeready-workspaces-udi/Dockerfile
+++ b/codeready-workspaces-udi/Dockerfile
@@ -73,6 +73,8 @@ RUN \
         echo "Changing permissions on ${f}" && chgrp -R 0 ${f} && \
         chmod -R g+rwX ${f}; \
     done && \
+    # add user and configure it
+    useradd -u 1000 -G wheel,root -d /home/user --shell /bin/bash -m user && \
     # Generate passwd.template \
     cat /etc/passwd | \
     sed s#user:x.*#user:x:\${USER_ID}:\${GROUP_ID}::\${HOME}:/bin/bash#g \


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>
Adds user and configure it in UDI. It should fix a problem with folder creation in `/home/user` like `/home/user/.m2` during the maven build command. 