### PR TITLE
Fixes for CRW-2464

### DIFF
--- a/codeready-workspaces-udi-openj9/Dockerfile
+++ b/codeready-workspaces-udi-openj9/Dockerfile
@@ -44,7 +44,7 @@ COPY . /tmp/assets/
 COPY etc/docker.sh /usr/local/bin/docker
 COPY lombok-${LOMBOK_VERSION}.jar /lombok.jar
 COPY gradle-${GRADLE_VERSION}-bin.zip apache-maven-${MAVEN_VERSION}-bin.tar.gz /tmp/
-COPY bin.tgz /tmp/
+COPY asset-odo.tgz /tmp/
 
 # NOTE: uncomment for local build. Must also set full registry path in FROM to registry.redhat.io or registry.access.redhat.com
 # enable rhel 8 content sets (from Brew) to resolve buildah

--- a/codeready-workspaces-udi-openj9/Dockerfile
+++ b/codeready-workspaces-udi-openj9/Dockerfile
@@ -139,7 +139,7 @@ RUN \
     ########################################################################
 RUN \
     if [[ -f /usr/local/bin/odo ]]; then rm -f /usr/local/bin/odo; fi; \
-    tar xzf /tmp/bin.tgz --strip=1 -C /usr/local/bin $(uname -m)/odo && rm -fr /tmp/bin.tgz
+    tar xzf /tmp/asset-odo.tgz --strip=1 -C /usr/local/bin $(uname -m)/odo && rm -fr /tmp/asset-odo.tgz
     ########################################################################
     # CPP
     ########################################################################

--- a/codeready-workspaces-udi/Dockerfile
+++ b/codeready-workspaces-udi/Dockerfile
@@ -47,7 +47,7 @@ COPY . /tmp/assets/
 COPY etc/docker.sh /usr/local/bin/docker
 COPY lombok-${LOMBOK_VERSION}.jar /lombok.jar
 COPY gradle-${GRADLE_VERSION}-bin.zip apache-maven-${MAVEN_VERSION}-bin.tar.gz /tmp/
-COPY bin.tgz /tmp/
+COPY asset-odo.tgz /tmp/
 
 # NOTE: uncomment for local build. Must also set full registry path in FROM to registry.redhat.io or registry.access.redhat.com
 # enable rhel 8 content sets (from Brew) to resolve buildah

--- a/codeready-workspaces-udi/Dockerfile
+++ b/codeready-workspaces-udi/Dockerfile
@@ -142,7 +142,7 @@ RUN \
     ########################################################################
 RUN \
     if [[ -f /usr/local/bin/odo ]]; then rm -f /usr/local/bin/odo; fi; \
-    tar xzf /tmp/bin.tgz --strip=1 -C /usr/local/bin $(uname -m)/odo && rm -fr /tmp/bin.tgz
+    tar xzf /tmp/asset-odo.tgz --strip=1 -C /usr/local/bin $(uname -m)/odo && rm -fr /tmp/asset-odo.tgz
     ########################################################################
     # CPP
     ########################################################################


### PR DESCRIPTION
fix: bin.tgz got renamed to asset-odo.tgz