### PR TITLE
chore: prepare /home/user/.venv directory when building UDI container

### DIFF
--- a/codeready-workspaces-udi/Dockerfile
+++ b/codeready-workspaces-udi/Dockerfile
@@ -122,8 +122,8 @@ RUN \
         cp -R /tmp/py-unpack/bin/* /usr/bin && \
         cp -R /tmp/py-unpack/lib/* /usr/lib && \
         cp -R /tmp/py-unpack/lib64/* /usr/lib64 && \
-        cp -R /tmp/py-unpack/.venv "${HOME}/.venv-tmp" && \
-        chgrp -R 0 "${HOME}/.venv-tmp" && chmod -R g+rwX "${HOME}/.venv-tmp" && \
+        cp -R /tmp/py-unpack/.venv ${HOME} && \
+        chgrp -R 0 ${HOME}/.venv && chmod -R g+rwX ${HOME}/.venv && \
         rm -fr /tmp/py-unpack \
     else \
         echo "[WARNING] Python lang server dependency tarball not found. Python support may be more limited on $(uname -m)"; \

--- a/codeready-workspaces-udi/etc/entrypoint.sh
+++ b/codeready-workspaces-udi/etc/entrypoint.sh
@@ -36,15 +36,14 @@ if [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1 && sudo -n true > /de
     sudo chown "${USER_ID}:${GROUP_ID}" /projects
 fi
 
-# Setup .venv in the 'venv' volume that should be mounted in HOME/.venv
-mkdir -p "${HOME}"/.venv
-if [ ! -f "${HOME}"/.venv/bin/activate ]; then
-  echo "${HOME}"/.venv is empty, moving files from "${HOME}"/.venv-tmp/
-  mv "${HOME}"/.venv-tmp/* "${HOME}"/.venv
+if [ -f "${HOME}"/.venv/bin/activate ]; then
+  source "${HOME}"/.venv/bin/activate
 fi
 
-# shellcheck source=/dev/null
-source "${HOME}"/.venv/bin/activate
+# Setup $PS1 for a consistent and reasonable prompt
+if [ -w "${HOME}" ] && [ ! -f "${HOME}"/.bashrc ]; then
+  echo "PS1='[\u@\h \W]\$ '" > "${HOME}"/.bashrc
+fi
 
 if [[ ! -z "${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}" ]]; then
   ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

- Instead of copying `/home/user/.venv-tmp` to `/home/user/.venv` on container startup, it's better to prepare `/home/user/.venv` when building the UDI image. It reduces the workspace startup time by around one minute (the time required to moving resources https://github.com/redhat-developer/codeready-workspaces-images/blob/crw-2-rhel-8/codeready-workspaces-udi/etc/entrypoint.sh#L43 ).

- It improves the terminal prompt as well.
