### PR TITLE
chore: turn on java 8 if USE_JAVA8 env. variable is set to true

### DIFF
--- a/codeready-workspaces-udi/Dockerfile
+++ b/codeready-workspaces-udi/Dockerfile
@@ -30,8 +30,9 @@ ENV \
     CPATH="/usr/include${CPATH:+:${CPATH}}" \
     DOTNET_RPM_VERSION=3.1 \
     DOTNET_CLI_TELEMETRY_OPTOUT=1 \
-    JAVA_HOME=/usr/lib/jvm/java-11-openjdk \
-    PATH="/usr/lib/jvm/java-11-openjdk:/usr/lib/jvm/java-1.8.0-openjdk:$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:/opt/app-root/src/.npm-global/bin/:/opt/apache-maven/bin:/opt/gradle/bin:/usr/bin:${PATH:-/bin:/usr/bin}" \
+    JAVA11_HOME=/usr/lib/jvm/java-11-openjdk \
+    JAVA8_HOME=/usr/lib/jvm/java-1.8.0-openjdk \
+    PATH="$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:/opt/app-root/src/.npm-global/bin/:/opt/apache-maven/bin:/opt/gradle/bin:/usr/bin:${PATH:-/bin:/usr/bin}" \
     MANPATH="/usr/share/man:${MANPATH}" \
     JAVACONFDIRS="/etc/java${JAVACONFDIRS:+:}${JAVACONFDIRS:-}" \
     XDG_CONFIG_DIRS="/etc/xdg:${XDG_CONFIG_DIRS:-/etc/xdg}" \

--- a/codeready-workspaces-udi/etc/entrypoint.sh
+++ b/codeready-workspaces-udi/etc/entrypoint.sh
@@ -31,7 +31,9 @@ if ! grep -Fq "${USER_ID}" /etc/passwd; then
     sed "s/\${HOME}/\/home\/user/g" > /etc/group
 fi
 
+#############################################################################
 # Grant access to projects volume in case of non root user with sudo rights
+#############################################################################
 if [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1 && sudo -n true > /dev/null 2>&1; then
     sudo chown "${USER_ID}:${GROUP_ID}" /projects
 fi
@@ -40,10 +42,30 @@ if [ -f "${HOME}"/.venv/bin/activate ]; then
   source "${HOME}"/.venv/bin/activate
 fi
 
+#############################################################################
 # Setup $PS1 for a consistent and reasonable prompt
+#############################################################################
 if [ -w "${HOME}" ] && [ ! -f "${HOME}"/.bashrc ]; then
   echo "PS1='[\u@\h \W]\$ '" > "${HOME}"/.bashrc
 fi
+
+#############################################################################
+# Use java 8 if USE_JAVA8 is set to 'true'
+#############################################################################
+if [ "${USE_JAVA8}" == "true" ] && [ ! -z "${JAVA8_HOME}" ]; then
+  export JAVA_HOME=${JAVA8_HOME}
+  export PATH="${JAVA8_HOME}/bin:${PATH}"
+else
+  if [ ! -z "${JAVA11_HOME}" ]; then
+    export JAVA_HOME=${JAVA11_HOME}
+    export PATH="${JAVA11_HOME}/bin:${PATH}"
+  else
+    echo "Java environment is not configured"
+  fi
+fi
+
+unset JAVA8_HOME
+unset JAVA11_HOME
 
 if [[ ! -z "${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}" ]]; then
   ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

Makes it possible to switch between java 8 and java 1
To turn on java 8 ( 1.8 ), the environment variable `USE_JAVA8` should be set to `true`

```
  - name: tools
    container:
      image: quay.io/crw/udi-rhel8:2.16
      memoryLimit: 3Gi
      endpoints:
        - exposure: public
          name: http-booster
          protocol: http
          targetPort: 8080
        - exposure: internal
          name: debug
          protocol: http
          targetPort: 5005
      volumeMounts:
        - name: m2
          path: /home/user/.m2
      env:
        - name: USE_JAVA8
          value: true
```
